### PR TITLE
fix: stabilize Hyprland 0.55 plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ plugin:hyprglass {
 }
 ```
 
+### Lua config
+
+When using Hyprland's Lua config, use dot-separated keys:
+
+```lua
+hl.config({
+  ["plugin.hyprglass.enabled"] = 1,
+  ["plugin.hyprglass.default_theme"] = "dark",
+  ["plugin.hyprglass.default_preset"] = "clear",
+  ["plugin.hyprglass.tint_color"] = 0x8899aa22,
+
+  ["plugin.hyprglass.layers.enabled"] = 1,
+  ["plugin.hyprglass.layers.namespaces"] = "waybar, notifications",
+})
+
+if hl.plugin.hyprglass and hl.plugin.hyprglass.preset then
+  hl.plugin.hyprglass.preset("name:clear, glass_opacity:0.8, blur_strength:1.5")
+  hl.plugin.hyprglass.preset("name:clear:dark, brightness:0.7")
+end
+```
+
 ### Global-only settings
 
 | Option | Type | Default | Description |

--- a/src/GlassDecoration.cpp
+++ b/src/GlassDecoration.cpp
@@ -90,7 +90,7 @@ void CGlassDecoration::draw(PHLMONITOR monitor, float const& alpha) {
     if (!g_pGlobalState || !resolveEnabled())
         return;
 
-    CGlassPassElement::SGlassPassData data{this, alpha};
+    CGlassPassElement::SGlassPassData data{m_self, alpha};
     g_pHyprRenderer->m_renderPass.add(makeUnique<CGlassPassElement>(data));
 
     const auto window = m_window.lock();

--- a/src/GlassDecoration.cpp
+++ b/src/GlassDecoration.cpp
@@ -49,11 +49,9 @@ bool CGlassDecoration::resolveThemeIsDark() const {
         }
 
         const auto& config = g_pGlobalState->config;
-        if (config.defaultTheme) {
-            const char* theme = *config.defaultTheme;
-            if (theme)
-                return std::string_view(theme) != "light";
-        }
+        const auto theme = readStringConfig(config.defaultTheme);
+        if (!theme.empty())
+            return theme != "light";
     } catch (...) {}
 
     return true;
@@ -70,11 +68,9 @@ std::string CGlassDecoration::resolvePresetName() const {
         }
 
         const auto& config = g_pGlobalState->config;
-        if (config.defaultPreset) {
-            const char* preset = *config.defaultPreset;
-            if (preset && preset[0] != '\0')
-                return std::string(preset);
-        }
+        const auto preset = readStringConfig(config.defaultPreset);
+        if (!preset.empty())
+            return std::string(preset);
     } catch (...) {}
 
     return "default";
@@ -138,7 +134,9 @@ void CGlassDecoration::renderPass(PHLMONITOR monitor, const float& alpha) {
     if (!window)
         return;
 
-    const auto source = g_pHyprOpenGL->m_renderData.currentFB;
+    const auto source = g_pHyprRenderer->m_renderData.currentFB;
+    if (!source)
+        return;
 
     auto optBox = WindowGeometry::computeWindowBox(window, monitor);
     if (!optBox)
@@ -148,10 +146,10 @@ void CGlassDecoration::renderPass(PHLMONITOR monitor, const float& alpha) {
     CBox transformBox = windowBox;
 
     const auto transform = Math::wlTransformToHyprutils(
-        Math::invertTransform(g_pHyprOpenGL->m_renderData.pMonitor->m_transform));
+        Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
     transformBox.transform(transform,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
+        g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x,
+        g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y);
 
     const bool isDark          = resolveThemeIsDark();
     const std::string preset   = resolvePresetName();
@@ -160,19 +158,19 @@ void CGlassDecoration::renderPass(PHLMONITOR monitor, const float& alpha) {
     float blurStrength   = resolvePresetFloat(ctx, &SPresetValues::blurStrength, &SOverridableConfig::blurStrength);
     int downscale        = blurStrength >= GlassRenderer::BLUR_DOWNSCALE_THRESHOLD ? GlassRenderer::BLUR_DOWNSCALE_MAX : 1;
 
-    GlassRenderer::sampleBackground(m_sampleFramebuffer, *source, transformBox, m_samplePaddingRatio, downscale);
+    GlassRenderer::sampleBackground(m_sampleFramebuffer, source, transformBox, m_samplePaddingRatio, downscale);
 
     float blurRadius     = blurStrength * 12.0f / downscale;
     int blurIterations   = std::clamp(static_cast<int>(resolvePresetInt(ctx, &SPresetValues::blurIterations, &SOverridableConfig::blurIterations)), 1, 5);
-    int viewportWidth    = static_cast<int>(g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x);
-    int viewportHeight   = static_cast<int>(g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
-    GlassRenderer::blurBackground(m_sampleFramebuffer, blurRadius, blurIterations, source->getFBID(), viewportWidth, viewportHeight);
+    int viewportWidth    = static_cast<int>(g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x);
+    int viewportHeight   = static_cast<int>(g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y);
+    GlassRenderer::blurBackground(m_sampleFramebuffer, blurRadius, blurIterations, dynamic_cast<Render::GL::CGLFramebuffer*>(source.get())->getFBID(), viewportWidth, viewportHeight);
 
     float monitorScale  = monitor->m_scale;
     float cornerRadius  = window->rounding() * monitorScale;
     float roundingPower = window->roundingPower();
 
-    GlassRenderer::applyGlassEffect(m_sampleFramebuffer, *source,
+    GlassRenderer::applyGlassEffect(m_sampleFramebuffer, source,
                                      windowBox, transformBox, alpha,
                                      cornerRadius, roundingPower, m_samplePaddingRatio, ctx);
 }

--- a/src/GlassDecoration.hpp
+++ b/src/GlassDecoration.hpp
@@ -29,7 +29,7 @@ class CGlassDecoration : public IHyprWindowDecoration {
 
   private:
     PHLWINDOWREF m_window;
-    CFramebuffer m_sampleFramebuffer;
+    SP<Render::IFramebuffer> m_sampleFramebuffer;
     Vector2D     m_samplePaddingRatio;
 
     // Track last rendered position/size to detect actual changes and seed damage

--- a/src/GlassLayerCompositeElement.cpp
+++ b/src/GlassLayerCompositeElement.cpp
@@ -4,16 +4,16 @@
 #include "Globals.hpp"
 #include "LayerGeometry.hpp"
 
-#include <hyprland/src/render/OpenGL.hpp>
+#include <cmath>
 
 CGlassLayerCompositeElement::CGlassLayerCompositeElement(const SGlassLayerCompositeData& data)
     : m_data(data) {}
 
-void CGlassLayerCompositeElement::draw(const CRegion& damage) {
-    if (!m_data.layerState || !m_data.layerState->getLayerSurface())
-        return;
+std::vector<UP<IPassElement>> CGlassLayerCompositeElement::draw() {
+    if (m_data.layerState && m_data.layerState->getLayerSurface())
+        m_data.layerState->compositeAndRestore(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.alpha);
 
-    m_data.layerState->compositeAndRestore(g_pHyprOpenGL->m_renderData.pMonitor.lock(), m_data.alpha);
+    return {};
 }
 
 std::optional<CBox> CGlassLayerCompositeElement::boundingBox() {
@@ -24,13 +24,16 @@ std::optional<CBox> CGlassLayerCompositeElement::boundingBox() {
     if (!layerSurface)
         return std::nullopt;
 
-    const auto monitor = g_pHyprOpenGL->m_renderData.pMonitor.lock();
+    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor.lock();
     auto box = LayerGeometry::computeLayerBox(layerSurface, monitor);
     if (!box)
         return std::nullopt;
 
-    const float padding = GlassRenderer::SAMPLE_PADDING_PX / monitor->m_scale;
-    box->expand(padding);
+    const float scale = monitor->m_scale > 0.0f ? monitor->m_scale : 1.0f;
+    box->scale(1.0 / scale).expand(GlassRenderer::SAMPLE_PADDING_PX / scale).noNegativeSize().round();
+    if (!std::isfinite(box->x) || !std::isfinite(box->y) || !std::isfinite(box->w) || !std::isfinite(box->h) || box->w <= 0.0 || box->h <= 0.0)
+        return std::nullopt;
+
     return box;
 }
 

--- a/src/GlassLayerCompositeElement.hpp
+++ b/src/GlassLayerCompositeElement.hpp
@@ -17,12 +17,13 @@ class CGlassLayerCompositeElement : public IPassElement {
     explicit CGlassLayerCompositeElement(const SGlassLayerCompositeData& data);
     ~CGlassLayerCompositeElement() override = default;
 
-    void                draw(const CRegion& damage) override;
+    std::vector<UP<IPassElement>> draw() override;
     [[nodiscard]] bool                needsLiveBlur() override;
     [[nodiscard]] bool                needsPrecomputeBlur() override;
     [[nodiscard]] std::optional<CBox> boundingBox() override;
 
     [[nodiscard]] const char* passName() override { return "CGlassLayerCompositeElement"; }
+    [[nodiscard]] ePassElementType type() override { return EK_CUSTOM; }
 
   private:
     SGlassLayerCompositeData m_data;

--- a/src/GlassLayerPassElement.cpp
+++ b/src/GlassLayerPassElement.cpp
@@ -4,16 +4,16 @@
 #include "Globals.hpp"
 #include "LayerGeometry.hpp"
 
-#include <hyprland/src/render/OpenGL.hpp>
+#include <cmath>
 
 CGlassLayerPassElement::CGlassLayerPassElement(const SGlassLayerPassData& data)
     : m_data(data) {}
 
-void CGlassLayerPassElement::draw(const CRegion& damage) {
-    if (!m_data.layerState || !m_data.layerState->getLayerSurface())
-        return;
+std::vector<UP<IPassElement>> CGlassLayerPassElement::draw() {
+    if (m_data.layerState && m_data.layerState->getLayerSurface())
+        m_data.layerState->sampleAndRedirect(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.alpha);
 
-    m_data.layerState->sampleAndRedirect(g_pHyprOpenGL->m_renderData.pMonitor.lock(), m_data.alpha);
+    return {};
 }
 
 std::optional<CBox> CGlassLayerPassElement::boundingBox() {
@@ -24,13 +24,16 @@ std::optional<CBox> CGlassLayerPassElement::boundingBox() {
     if (!layerSurface)
         return std::nullopt;
 
-    const auto monitor = g_pHyprOpenGL->m_renderData.pMonitor.lock();
+    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor.lock();
     auto box = LayerGeometry::computeLayerBox(layerSurface, monitor);
     if (!box)
         return std::nullopt;
 
-    const float padding = GlassRenderer::SAMPLE_PADDING_PX / monitor->m_scale;
-    box->expand(padding);
+    const float scale = monitor->m_scale > 0.0f ? monitor->m_scale : 1.0f;
+    box->scale(1.0 / scale).expand(GlassRenderer::SAMPLE_PADDING_PX / scale).noNegativeSize().round();
+    if (!std::isfinite(box->x) || !std::isfinite(box->y) || !std::isfinite(box->w) || !std::isfinite(box->h) || box->w <= 0.0 || box->h <= 0.0)
+        return std::nullopt;
+
     return box;
 }
 

--- a/src/GlassLayerPassElement.hpp
+++ b/src/GlassLayerPassElement.hpp
@@ -17,13 +17,14 @@ class CGlassLayerPassElement : public IPassElement {
     explicit CGlassLayerPassElement(const SGlassLayerPassData& data);
     ~CGlassLayerPassElement() override = default;
 
-    void                draw(const CRegion& damage) override;
+    std::vector<UP<IPassElement>> draw() override;
     [[nodiscard]] bool                needsLiveBlur() override;
     [[nodiscard]] bool                needsPrecomputeBlur() override;
     [[nodiscard]] std::optional<CBox> boundingBox() override;
     [[nodiscard]] bool                disableSimplification() override;
 
     [[nodiscard]] const char* passName() override { return "CGlassLayerPassElement"; }
+    [[nodiscard]] ePassElementType type() override { return EK_CUSTOM; }
 
   private:
     SGlassLayerPassData m_data;

--- a/src/GlassLayerSurface.cpp
+++ b/src/GlassLayerSurface.cpp
@@ -5,11 +5,18 @@
 #include "LayerGeometry.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <hyprland/src/desktop/Workspace.hpp>
 #include <GLES3/gl32.h>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprutils/math/Misc.hpp>
+
+static CBox transformedLayerBox(CBox pixelBox, PHLMONITOR monitor) {
+    const auto transform = Math::wlTransformToHyprutils(Math::invertTransform(monitor->m_transform));
+    pixelBox.transform(transform, monitor->m_transformedSize.x, monitor->m_transformedSize.y).noNegativeSize().round();
+    return pixelBox;
+}
 
 CGlassLayerSurface::CGlassLayerSurface(PHLLS layerSurface)
     : m_layerSurface(layerSurface) {
@@ -18,21 +25,22 @@ CGlassLayerSurface::CGlassLayerSurface(PHLLS layerSurface)
 CGlassLayerSurface::~CGlassLayerSurface() {
     // Damage the area where glass was last drawn so the compositor
     // re-renders it without the glass effect (prevents ghost artifacts).
-    if (g_pHyprRenderer && m_lastSize.x > 0 && m_lastSize.y > 0) {
+    if (g_pHyprRenderer && m_lastSize.x > 0 && m_lastSize.y > 0 &&
+        std::isfinite(m_lastPosition.x) && std::isfinite(m_lastPosition.y) &&
+        std::isfinite(m_lastSize.x) && std::isfinite(m_lastSize.y)) {
         auto box = CBox{m_lastPosition, m_lastSize};
-        box.expand(GlassRenderer::SAMPLE_PADDING_PX);
-        g_pHyprRenderer->damageBox(box);
+        box.expand(GlassRenderer::SAMPLE_PADDING_PX).noNegativeSize();
+        if (box.w > 0.0 && box.h > 0.0)
+            g_pHyprRenderer->damageBox(box);
     }
 }
 
 bool CGlassLayerSurface::resolveThemeIsDark() const {
     try {
         const auto& config = g_pGlobalState->config;
-        if (config.defaultTheme) {
-            const char* theme = *config.defaultTheme;
-            if (theme)
-                return std::string_view(theme) != "light";
-        }
+        const auto theme = readStringConfig(config.defaultTheme);
+        if (!theme.empty())
+            return theme != "light";
     } catch (...) {}
 
     return true;
@@ -52,18 +60,14 @@ std::string CGlassLayerSurface::resolvePresetName() const {
         const auto& config = g_pGlobalState->config;
 
         // Layer-wide preset override
-        if (config.layersPreset) {
-            const char* preset = *config.layersPreset;
-            if (preset && preset[0] != '\0')
-                return std::string(preset);
-        }
+        const auto layerPreset = readStringConfig(config.layersPreset);
+        if (!layerPreset.empty())
+            return std::string(layerPreset);
 
         // Fall back to global default preset
-        if (config.defaultPreset) {
-            const char* preset = *config.defaultPreset;
-            if (preset && preset[0] != '\0')
-                return std::string(preset);
-        }
+        const auto defaultPreset = readStringConfig(config.defaultPreset);
+        if (!defaultPreset.empty())
+            return std::string(defaultPreset);
     } catch (...) {}
 
     return "default";
@@ -80,6 +84,10 @@ void CGlassLayerSurface::damageIfMoved() {
 
     const auto currentPosition = layerSurface->m_realPosition->value();
     const auto currentSize     = layerSurface->m_realSize->value();
+    if (currentSize.x <= 0.0 || currentSize.y <= 0.0 ||
+        !std::isfinite(currentPosition.x) || !std::isfinite(currentPosition.y) ||
+        !std::isfinite(currentSize.x) || !std::isfinite(currentSize.y))
+        return;
 
     const bool isAnimating = layerSurface->m_realPosition->isBeingAnimated() ||
                              layerSurface->m_realSize->isBeingAnimated() ||
@@ -95,8 +103,9 @@ void CGlassLayerSurface::damageIfMoved() {
         auto box = CBox{currentPosition, currentSize};
         const auto monitor = layerSurface->m_monitor.lock();
         const float scale = monitor ? monitor->m_scale : 1.0f;
-        box.expand(GlassRenderer::SAMPLE_PADDING_PX / scale);
-        g_pHyprRenderer->damageBox(box);
+        box.expand(GlassRenderer::SAMPLE_PADDING_PX / scale).noNegativeSize();
+        if (box.w > 0.0 && box.h > 0.0)
+            g_pHyprRenderer->damageBox(box);
 
         if (monitor)
             g_pGlobalState->bumpSceneGeneration(monitor.get());
@@ -114,19 +123,15 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     if (!layerSurface)
         return;
 
-    auto* source = g_pHyprOpenGL->m_renderData.currentFB;
+    auto source = g_pHyprRenderer->m_renderData.currentFB;
+    if (!source)
+        return;
 
     auto layerBox = LayerGeometry::computeLayerBox(layerSurface, monitor);
     if (!layerBox)
         return;
 
-    CBox transformBox = *layerBox;
-
-    const auto transform = Math::wlTransformToHyprutils(
-        Math::invertTransform(g_pHyprOpenGL->m_renderData.pMonitor->m_transform));
-    transformBox.transform(transform,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
+    CBox transformBox = transformedLayerBox(*layerBox, monitor);
 
     // Decide whether we need to re-sample and re-blur the background.
     // When only the layer surface content changed (e.g. waybar clock tick)
@@ -154,13 +159,13 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
         float blurStrength   = resolvePresetFloat(ctx, &SPresetValues::blurStrength, &SOverridableConfig::blurStrength);
         int downscale        = blurStrength >= GlassRenderer::BLUR_DOWNSCALE_THRESHOLD ? GlassRenderer::BLUR_DOWNSCALE_MAX : 1;
 
-        GlassRenderer::sampleBackground(m_sampleFramebuffer, *source, transformBox, m_samplePaddingRatio, downscale);
+        GlassRenderer::sampleBackground(m_sampleFramebuffer, source, transformBox, m_samplePaddingRatio, downscale);
 
         float blurRadius     = blurStrength * 12.0f / downscale;
         int blurIterations   = std::clamp(static_cast<int>(resolvePresetInt(ctx, &SPresetValues::blurIterations, &SOverridableConfig::blurIterations)), 1, 5);
-        int viewportWidth    = static_cast<int>(g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x);
-        int viewportHeight   = static_cast<int>(g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
-        GlassRenderer::blurBackground(m_sampleFramebuffer, blurRadius, blurIterations, source->getFBID(), viewportWidth, viewportHeight);
+        int viewportWidth    = static_cast<int>(g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x);
+        int viewportHeight   = static_cast<int>(g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y);
+        GlassRenderer::blurBackground(m_sampleFramebuffer, blurRadius, blurIterations, dynamic_cast<Render::GL::CGLFramebuffer*>(source.get())->getFBID(), viewportWidth, viewportHeight);
 
         m_hasCachedSample      = true;
         m_lastSceneGeneration  = currentGeneration;
@@ -177,39 +182,36 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     // Monitor FBOs use XRGB formats (no usable alpha); XRGB2101010 (10-bit)
     // has only 2-bit alpha, quantizing values below ~0.17 to zero and breaking
     // the mask discard for low-opacity layers.
-    if (m_surfaceTempFramebuffer.m_size.x != monitorWidth || m_surfaceTempFramebuffer.m_size.y != monitorHeight)
-        m_surfaceTempFramebuffer.alloc(monitorWidth, monitorHeight, DRM_FORMAT_ARGB8888);
+    if (!m_surfaceTempFramebuffer)
+        m_surfaceTempFramebuffer = g_pHyprRenderer->createFB("hyprglass-layer-temp");
+
+    if (m_surfaceTempFramebuffer->m_size.x != monitorWidth || m_surfaceTempFramebuffer->m_size.y != monitorHeight)
+        m_surfaceTempFramebuffer->alloc(monitorWidth, monitorHeight, DRM_FORMAT_ARGB8888);
 
     m_savedCurrentFB = source;
 
-    g_pHyprOpenGL->m_renderData.currentFB = &m_surfaceTempFramebuffer;
-    glBindFramebuffer(GL_FRAMEBUFFER, m_surfaceTempFramebuffer.getFBID());
+    g_pHyprRenderer->m_renderData.currentFB = m_surfaceTempFramebuffer;
+    glBindFramebuffer(GL_FRAMEBUFFER, dynamic_cast<Render::GL::CGLFramebuffer*>(m_surfaceTempFramebuffer.get())->getFBID());
 
-    // Scissored clear: only clear the layer's area + margin in the temp FBO.
-    // The mask shader only reads within the layer's UV bounds, so content outside
-    // doesn't matter. This avoids clearing millions of unused pixels on
-    // monitor-sized FBOs (e.g. 48x48 layer on a 2560x1440 FBO).
-    {
-        const int pad = GlassRenderer::SAMPLE_PADDING_PX;
-        const int sx  = std::max(0, static_cast<int>(transformBox.x) - pad);
-        const int sy  = std::max(0, static_cast<int>(transformBox.y) - pad);
-        const int sw  = std::min(monitorWidth  - sx, static_cast<int>(transformBox.w) + 2 * pad);
-        const int sh  = std::min(monitorHeight - sy, static_cast<int>(transformBox.h) + 2 * pad);
-        glEnable(GL_SCISSOR_TEST);
-        glScissor(sx, sy, sw, sh);
+    CBox clearBox = transformBox;
+    clearBox.expand(GlassRenderer::SAMPLE_PADDING_PX);
+    clearBox = clearBox.intersection(CBox{0.0, 0.0, static_cast<double>(monitorWidth), static_cast<double>(monitorHeight)}).noNegativeSize().round();
+
+    if (std::isfinite(clearBox.x) && std::isfinite(clearBox.y) && std::isfinite(clearBox.w) && std::isfinite(clearBox.h) &&
+        clearBox.w > 0.0 && clearBox.h > 0.0) {
+        g_pHyprOpenGL->scissor(clearBox, false);
         glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
         glClear(GL_COLOR_BUFFER_BIT);
-        glDisable(GL_SCISSOR_TEST);
-        g_pHyprOpenGL->setCapStatus(GL_SCISSOR_TEST, false);
+        g_pHyprOpenGL->scissor(nullptr);
     }
 }
 
 void CGlassLayerSurface::compositeAndRestore(PHLMONITOR monitor, float alpha) {
     // Restore the original currentFB before compositing
     if (m_savedCurrentFB) {
-        g_pHyprOpenGL->m_renderData.currentFB = m_savedCurrentFB;
-        glBindFramebuffer(GL_FRAMEBUFFER, m_savedCurrentFB->getFBID());
-        m_savedCurrentFB = nullptr;
+        g_pHyprRenderer->m_renderData.currentFB = m_savedCurrentFB;
+        glBindFramebuffer(GL_FRAMEBUFFER, dynamic_cast<Render::GL::CGLFramebuffer*>(m_savedCurrentFB.get())->getFBID());
+        m_savedCurrentFB.reset();
     }
 
     auto& shaderManager = g_pGlobalState->shaderManager;
@@ -220,20 +222,16 @@ void CGlassLayerSurface::compositeAndRestore(PHLMONITOR monitor, float alpha) {
     if (!layerSurface)
         return;
 
-    auto* target = g_pHyprOpenGL->m_renderData.currentFB;
+    auto target = g_pHyprRenderer->m_renderData.currentFB;
+    if (!target)
+        return;
 
     auto layerBox = LayerGeometry::computeLayerBox(layerSurface, monitor);
     if (!layerBox)
         return;
 
     CBox rawBox       = *layerBox;
-    CBox transformBox = rawBox;
-
-    const auto transform = Math::wlTransformToHyprutils(
-        Math::invertTransform(g_pHyprOpenGL->m_renderData.pMonitor->m_transform));
-    transformBox.transform(transform,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x,
-        g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
+    CBox transformBox = transformedLayerBox(rawBox, monitor);
 
     const bool isDark          = resolveThemeIsDark();
     const std::string preset   = resolvePresetName();
@@ -254,16 +252,16 @@ void CGlassLayerSurface::compositeAndRestore(PHLMONITOR monitor, float alpha) {
         maskThreshold = threshIt->second;
 
     GlassRenderer::SMaskInfo maskInfo{
-        .textureId      = m_surfaceTempFramebuffer.getTexture()->m_texID,
-        .target         = GL_TEXTURE_2D,
-        .uvOffset       = {transformBox.x / monitorWidth, transformBox.y / monitorHeight},
-        .uvScale        = {transformBox.w / monitorWidth, transformBox.h / monitorHeight},
-        .alphaThreshold = maskThreshold,
+        .textureId         = m_surfaceTempFramebuffer->getTexture()->m_texID,
+        .target            = GL_TEXTURE_2D,
+        .uvOffset          = {transformBox.x / monitorWidth, transformBox.y / monitorHeight},
+        .uvScale           = {transformBox.w / monitorWidth, transformBox.h / monitorHeight},
+        .alphaThreshold    = maskThreshold,
     };
 
     // The glass shader composites both the glass effect and the surface content
     // in a single pass: glass behind, surface on top, using the temp FBO alpha.
-    GlassRenderer::applyGlassEffect(m_sampleFramebuffer, *target,
+    GlassRenderer::applyGlassEffect(m_sampleFramebuffer, target,
                                      rawBox, transformBox, alpha,
                                      cornerRadius, roundingPower, m_samplePaddingRatio, ctx,
                                      &maskInfo);

--- a/src/GlassLayerSurface.hpp
+++ b/src/GlassLayerSurface.hpp
@@ -23,8 +23,8 @@ class CGlassLayerSurface {
 
   private:
     PHLLSREF     m_layerSurface;
-    CFramebuffer m_sampleFramebuffer;
-    CFramebuffer m_surfaceTempFramebuffer;
+    SP<Render::IFramebuffer> m_sampleFramebuffer;
+    SP<Render::IFramebuffer> m_surfaceTempFramebuffer;
     Vector2D     m_samplePaddingRatio;
     bool         m_hasCachedSample = false;
 
@@ -37,7 +37,7 @@ class CGlassLayerSurface {
     uint64_t     m_lastSceneGeneration = 0;
 
     // Saved currentFB pointer, restored in compositeAndRestore
-    CFramebuffer* m_savedCurrentFB = nullptr;
+    SP<Render::IFramebuffer> m_savedCurrentFB;
 
     [[nodiscard]] bool        resolveThemeIsDark() const;
     [[nodiscard]] std::string resolvePresetName() const;

--- a/src/GlassPassElement.cpp
+++ b/src/GlassPassElement.cpp
@@ -7,14 +7,14 @@ CGlassPassElement::CGlassPassElement(const SGlassPassData& data)
     : m_data(data) {}
 
 std::vector<UP<IPassElement>> CGlassPassElement::draw() {
-    if (m_data.decoration)
+    if (m_data.decoration.valid())
         m_data.decoration->renderPass(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.alpha);
 
     return {};
 }
 
 std::optional<CBox> CGlassPassElement::boundingBox() {
-    if (!m_data.decoration)
+    if (!m_data.decoration.valid())
         return std::nullopt;
 
     auto window = m_data.decoration->getOwner();
@@ -41,7 +41,7 @@ bool CGlassPassElement::needsLiveBlur() {
     // in the padded sampling region, causing blinking artifacts.
     // Layers don't need this — they have their own blur cache with
     // scene generation tracking.
-    return m_data.decoration && m_data.decoration->getOwner();
+    return m_data.decoration.valid() && m_data.decoration->getOwner();
 }
 
 bool CGlassPassElement::needsPrecomputeBlur() {
@@ -49,5 +49,5 @@ bool CGlassPassElement::needsPrecomputeBlur() {
 }
 
 bool CGlassPassElement::disableSimplification() {
-    return m_data.decoration && m_data.decoration->getOwner();
+    return m_data.decoration.valid() && m_data.decoration->getOwner();
 }

--- a/src/GlassPassElement.cpp
+++ b/src/GlassPassElement.cpp
@@ -3,16 +3,14 @@
 #include "Globals.hpp"
 #include "WindowGeometry.hpp"
 
-#include <hyprland/src/render/OpenGL.hpp>
-
 CGlassPassElement::CGlassPassElement(const SGlassPassData& data)
     : m_data(data) {}
 
-void CGlassPassElement::draw(const CRegion& damage) {
-    if (!m_data.decoration)
-        return;
+std::vector<UP<IPassElement>> CGlassPassElement::draw() {
+    if (m_data.decoration)
+        m_data.decoration->renderPass(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.alpha);
 
-    m_data.decoration->renderPass(g_pHyprOpenGL->m_renderData.pMonitor.lock(), m_data.alpha);
+    return {};
 }
 
 std::optional<CBox> CGlassPassElement::boundingBox() {
@@ -23,7 +21,7 @@ std::optional<CBox> CGlassPassElement::boundingBox() {
     if (!window)
         return std::nullopt;
 
-    const auto monitor = g_pHyprOpenGL->m_renderData.pMonitor.lock();
+    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor.lock();
     auto box = WindowGeometry::computeWindowBox(window, monitor);
     if (!box)
         return std::nullopt;

--- a/src/GlassPassElement.hpp
+++ b/src/GlassPassElement.hpp
@@ -3,14 +3,15 @@
 #include <hyprland/src/render/pass/PassElement.hpp>
 #include <hyprutils/math/Box.hpp>
 #include <hyprutils/math/Region.hpp>
+#include <hyprland/src/helpers/memory/Memory.hpp>
 
 class CGlassDecoration;
 
 class CGlassPassElement : public IPassElement {
   public:
     struct SGlassPassData {
-        CGlassDecoration* decoration = nullptr;
-        float             alpha      = 1.0f;
+        WP<CGlassDecoration> decoration;
+        float                alpha = 1.0f;
     };
 
     explicit CGlassPassElement(const SGlassPassData& data);

--- a/src/GlassPassElement.hpp
+++ b/src/GlassPassElement.hpp
@@ -16,13 +16,14 @@ class CGlassPassElement : public IPassElement {
     explicit CGlassPassElement(const SGlassPassData& data);
     ~CGlassPassElement() override = default;
 
-    void                draw(const CRegion& damage) override;
+    std::vector<UP<IPassElement>> draw() override;
     [[nodiscard]] bool                needsLiveBlur() override;
     [[nodiscard]] bool                needsPrecomputeBlur() override;
     [[nodiscard]] std::optional<CBox> boundingBox() override;
     [[nodiscard]] bool                disableSimplification() override;
 
     [[nodiscard]] const char* passName() override { return "CGlassPassElement"; }
+    [[nodiscard]] ePassElementType type() override { return EK_CUSTOM; }
 
   private:
     SGlassPassData m_data;

--- a/src/GlassRenderer.cpp
+++ b/src/GlassRenderer.cpp
@@ -9,6 +9,10 @@
 
 namespace GlassRenderer {
 
+static GLuint fbId(const SP<Render::IFramebuffer>& framebuffer) {
+    return dynamic_cast<Render::GL::CGLFramebuffer*>(framebuffer.get())->getFBID();
+}
+
 static void uploadThemeUniforms(const SResolveContext& ctx) {
     const auto& uniforms = g_pGlobalState->shaderManager.glassUniforms;
     const auto& glassShader = g_pGlobalState->shaderManager.glassShader;
@@ -24,8 +28,10 @@ static void uploadThemeUniforms(const SResolveContext& ctx) {
     glUniform1f(uniforms.adaptiveBoost, resolvePresetFloat(ctx, &SPresetValues::adaptiveBoost, &SOverridableConfig::adaptiveBoost, defaults.adaptiveBoost));
 }
 
-void sampleBackground(CFramebuffer& sampleFramebuffer, CFramebuffer& sourceFramebuffer,
+void sampleBackground(SP<Render::IFramebuffer>& sampleFramebuffer, SP<Render::IFramebuffer> sourceFramebuffer,
                        CBox box, Vector2D& outPaddingRatio, int downscale) {
+    if (!sourceFramebuffer)
+        return;
     const int pad = SAMPLE_PADDING_PX;
     int fullWidth  = static_cast<int>(box.width) + 2 * pad;
     int fullHeight = static_cast<int>(box.height) + 2 * pad;
@@ -35,8 +41,11 @@ void sampleBackground(CFramebuffer& sampleFramebuffer, CFramebuffer& sourceFrame
     int sampleWidth  = std::max(1, fullWidth / downscale);
     int sampleHeight = std::max(1, fullHeight / downscale);
 
-    if (sampleFramebuffer.m_size.x != sampleWidth || sampleFramebuffer.m_size.y != sampleHeight)
-        sampleFramebuffer.alloc(sampleWidth, sampleHeight, sourceFramebuffer.m_drmFormat);
+    if (!sampleFramebuffer)
+        sampleFramebuffer = g_pHyprRenderer->createFB("hyprglass-sample");
+
+    if (sampleFramebuffer->m_size.x != sampleWidth || sampleFramebuffer->m_size.y != sampleHeight)
+        sampleFramebuffer->alloc(sampleWidth, sampleHeight, sourceFramebuffer->m_drmFormat);
 
     int srcX0 = static_cast<int>(box.x) - pad;
     int srcX1 = static_cast<int>(box.x + box.width) + pad;
@@ -44,8 +53,8 @@ void sampleBackground(CFramebuffer& sampleFramebuffer, CFramebuffer& sourceFrame
     int srcY1 = static_cast<int>(box.y + box.height) + pad;
 
     // Clamp source coordinates to framebuffer bounds to avoid reading black/undefined pixels
-    int framebufferWidth  = static_cast<int>(sourceFramebuffer.m_size.x);
-    int framebufferHeight = static_cast<int>(sourceFramebuffer.m_size.y);
+    int framebufferWidth  = static_cast<int>(sourceFramebuffer->m_size.x);
+    int framebufferHeight = static_cast<int>(sourceFramebuffer->m_size.y);
 
     // Destination coords in downscaled FBO space
     int dstX0 = 0, dstY0 = 0, dstX1 = sampleWidth, dstY1 = sampleHeight;
@@ -72,29 +81,32 @@ void sampleBackground(CFramebuffer& sampleFramebuffer, CFramebuffer& sourceFrame
 
     // Clear the sample FBO before blitting. Clamped regions (near edges)
     // would otherwise contain uninitialized GPU memory (pink artifacts).
-    glBindFramebuffer(GL_FRAMEBUFFER, sampleFramebuffer.getFBID());
+    glBindFramebuffer(GL_FRAMEBUFFER, fbId(sampleFramebuffer));
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFramebuffer.getFBID());
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, sampleFramebuffer.getFBID());
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, fbId(sourceFramebuffer));
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbId(sampleFramebuffer));
     glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1,
                       dstX0, dstY0, dstX1, dstY1,
                       GL_COLOR_BUFFER_BIT, GL_LINEAR);
 }
 
-void blurBackground(CFramebuffer& sampleFramebuffer, float radius, int iterations,
+void blurBackground(SP<Render::IFramebuffer> sampleFramebuffer, float radius, int iterations,
                     GLuint callerFramebufferID, int viewportWidth, int viewportHeight) {
     auto& shaderManager = g_pGlobalState->shaderManager;
-    if (radius <= 0.0f || iterations <= 0 || !shaderManager.isInitialized())
+    if (!sampleFramebuffer || radius <= 0.0f || iterations <= 0 || !shaderManager.isInitialized())
         return;
 
-    int width  = static_cast<int>(sampleFramebuffer.m_size.x);
-    int height = static_cast<int>(sampleFramebuffer.m_size.y);
+    int width  = static_cast<int>(sampleFramebuffer->m_size.x);
+    int height = static_cast<int>(sampleFramebuffer->m_size.y);
 
     auto& blurTempFramebuffer = g_pGlobalState->blurTempFramebuffer;
-    if (blurTempFramebuffer.m_size.x != width || blurTempFramebuffer.m_size.y != height)
-        blurTempFramebuffer.alloc(width, height, sampleFramebuffer.m_drmFormat);
+    if (!blurTempFramebuffer)
+        blurTempFramebuffer = g_pHyprRenderer->createFB("hyprglass-blur-temp");
+
+    if (blurTempFramebuffer->m_size.x != width || blurTempFramebuffer->m_size.y != height)
+        blurTempFramebuffer->alloc(width, height, sampleFramebuffer->m_drmFormat);
 
     // Fullscreen quad projection: maps VAO positions [0,1] to clip space [-1,1]
     static constexpr std::array<float, 9> FULLSCREEN_PROJECTION = {
@@ -116,14 +128,14 @@ void blurBackground(CFramebuffer& sampleFramebuffer, float radius, int iteration
     // Ping-pong at full resolution: sampleFramebuffer ↔ blurTempFramebuffer
     for (int iteration = 0; iteration < iterations; iteration++) {
         // Horizontal pass: sampleFramebuffer → blurTempFramebuffer
-        glBindFramebuffer(GL_FRAMEBUFFER, blurTempFramebuffer.getFBID());
-        sampleFramebuffer.getTexture()->bind();
+        glBindFramebuffer(GL_FRAMEBUFFER, fbId(blurTempFramebuffer));
+        sampleFramebuffer->getTexture()->bind();
         glUniform2f(blurUniforms.direction, 1.0f / width, 0.0f);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
         // Vertical pass: blurTempFramebuffer → sampleFramebuffer
-        glBindFramebuffer(GL_FRAMEBUFFER, sampleFramebuffer.getFBID());
-        blurTempFramebuffer.getTexture()->bind();
+        glBindFramebuffer(GL_FRAMEBUFFER, fbId(sampleFramebuffer));
+        blurTempFramebuffer->getTexture()->bind();
         glUniform2f(blurUniforms.direction, 0.0f, 1.0f / height);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
@@ -134,24 +146,26 @@ void blurBackground(CFramebuffer& sampleFramebuffer, float radius, int iteration
     g_pHyprOpenGL->setViewport(0, 0, viewportWidth, viewportHeight);
 }
 
-void applyGlassEffect(CFramebuffer& sampleFramebuffer, CFramebuffer& targetFramebuffer,
+void applyGlassEffect(SP<Render::IFramebuffer> sampleFramebuffer, SP<Render::IFramebuffer> targetFramebuffer,
                        CBox& rawBox, CBox& transformedBox,
                        float alpha, float cornerRadius, float roundingPower,
                        const Vector2D& paddingRatio, const SResolveContext& resolveContext,
                        const SMaskInfo* mask) {
+    if (!sampleFramebuffer || !targetFramebuffer)
+        return;
+
     auto& shaderManager  = g_pGlobalState->shaderManager;
     const auto& uniforms = shaderManager.glassUniforms;
 
     const auto transform = Math::wlTransformToHyprutils(
-        Math::invertTransform(g_pHyprOpenGL->m_renderData.pMonitor->m_transform));
+        Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
 
-    Mat3x3 matrix   = g_pHyprOpenGL->m_renderData.monitorProjection.projectBox(rawBox, transform, rawBox.rot);
-    Mat3x3 glMatrix = g_pHyprOpenGL->m_renderData.projection.copy().multiply(matrix);
-    auto texture    = sampleFramebuffer.getTexture();
+    Mat3x3 glMatrix = g_pHyprRenderer->projectBoxToTarget(rawBox, transform);
+    auto texture    = sampleFramebuffer->getTexture();
 
     glMatrix.transpose();
 
-    glBindFramebuffer(GL_FRAMEBUFFER, targetFramebuffer.getFBID());
+    glBindFramebuffer(GL_FRAMEBUFFER, fbId(targetFramebuffer));
     glActiveTexture(GL_TEXTURE0);
     texture->bind();
 

--- a/src/GlassRenderer.hpp
+++ b/src/GlassRenderer.hpp
@@ -30,16 +30,16 @@ struct SMaskInfo {
     float    alphaThreshold = 0.001f;
 };
 
-void sampleBackground(CFramebuffer& sampleFramebuffer, CFramebuffer& sourceFramebuffer,
+void sampleBackground(SP<Render::IFramebuffer>& sampleFramebuffer, SP<Render::IFramebuffer> sourceFramebuffer,
                        CBox box, Vector2D& outPaddingRatio, int downscale = 1);
 
-void blurBackground(CFramebuffer& sampleFramebuffer, float radius, int iterations,
+void blurBackground(SP<Render::IFramebuffer> sampleFramebuffer, float radius, int iterations,
                     GLuint callerFramebufferID, int viewportWidth, int viewportHeight);
 
 // When mask is non-null (layers only), the shader composites the surface content
 // over the glass effect in a single pass. When mask is null (windows), the shader
 // outputs the glass effect alone.
-void applyGlassEffect(CFramebuffer& sampleFramebuffer, CFramebuffer& targetFramebuffer,
+void applyGlassEffect(SP<Render::IFramebuffer> sampleFramebuffer, SP<Render::IFramebuffer> targetFramebuffer,
                        CBox& rawBox, CBox& transformedBox,
                        float alpha, float cornerRadius, float roundingPower,
                        const Vector2D& paddingRatio, const SResolveContext& resolveContext,

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -6,6 +6,8 @@
 
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/render/Framebuffer.hpp>
+#include <hyprland/src/render/OpenGL.hpp>
+#include <hyprland/src/render/Renderer.hpp>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -23,7 +25,7 @@ struct SGlobalState {
     std::unordered_map<std::string, SCustomPreset> customPresets;
 
     // Shared blur temp framebuffer (reused across all decorations since they render sequentially)
-    CFramebuffer blurTempFramebuffer;
+    SP<Render::IFramebuffer> blurTempFramebuffer;
 
     // Layer surface glass state (one per tracked layer, keyed by raw pointer).
     // shared_ptr so CGlassLayerPassElement can hold a copy that survives map erasure mid-frame.
@@ -53,6 +55,8 @@ struct SGlobalState {
     // renderLayer hook
     CFunctionHook* renderLayerHook = nullptr;
 };
+
+using Render::GL::g_pHyprOpenGL;
 
 inline HANDLE                        PHANDLE = nullptr;
 inline std::unique_ptr<SGlobalState> g_pGlobalState;

--- a/src/LayerGeometry.hpp
+++ b/src/LayerGeometry.hpp
@@ -3,6 +3,7 @@
 #include <hyprland/src/desktop/view/LayerSurface.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprutils/math/Box.hpp>
+#include <cmath>
 #include <optional>
 
 namespace LayerGeometry {
@@ -11,12 +12,14 @@ namespace LayerGeometry {
     if (!layerSurface || !monitor)
         return std::nullopt;
 
-    // Full animated layer geometry — the temp FBO mask constrains glass to visible
-    // content pixel-perfectly, so input region subsetting is not needed here.
+    // Full animated layer geometry in monitor-local framebuffer pixels.
     auto box = CBox{layerSurface->m_realPosition->value(), layerSurface->m_realSize->value()};
     box.translate(-monitor->m_position);
-    box.scale(monitor->m_scale);
-    box.round();
+    box.scale(monitor->m_scale).round().noNegativeSize();
+
+    if (!std::isfinite(box.x) || !std::isfinite(box.y) || !std::isfinite(box.w) || !std::isfinite(box.h) || box.w <= 0.0 || box.h <= 0.0)
+        return std::nullopt;
+
     return box;
 }
 

--- a/src/PluginConfig.cpp
+++ b/src/PluginConfig.cpp
@@ -4,92 +4,120 @@
 
 #include <algorithm>
 #include <charconv>
+#include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/values/ConfigValues.hpp>
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+}
+
 // ── Config registration ──────────────────────────────────────────────────────
 
+namespace {
+
+template <typename T, typename Default>
+static void addConfigValue(HANDLE handle, const char* name, Default defaultValue) {
+    HyprlandAPI::addConfigValueV2(handle,
+        Config::Values::makeConfigValue<T>(name, "", defaultValue, Config::Values::valueOptions_t<T>{}));
+}
+
+static int handleLuaPreset(lua_State* L) {
+    if (lua_gettop(L) < 1 || !lua_isstring(L, 1))
+        return luaL_error(L, "hyprglass.preset expects a preset definition string");
+
+    const auto result = handlePresetKeyword(ConfigKeys::PRESET_KEYWORD, lua_tostring(L, 1));
+    if (result.error)
+        return luaL_error(L, "%s", result.getError());
+
+    return 0;
+}
+
+} // namespace
+
 void registerConfig(HANDLE handle) {
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::ENABLED, Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DEFAULT_THEME, Hyprlang::STRING{"dark"});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DEFAULT_PRESET, Hyprlang::STRING{"default"});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::ENABLED, Config::INTEGER{1});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::DEFAULT_THEME, Config::STRING{"dark"});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::DEFAULT_PRESET, Config::STRING{"default"});
 
     // Layer surface support
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_ENABLED, Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_NAMESPACES, Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES, Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_PRESET, Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS, Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS, Hyprlang::STRING{""});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::LAYERS_ENABLED, Config::INTEGER{0});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_NAMESPACES, Config::STRING{});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES, Config::STRING{});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_PRESET, Config::STRING{});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS, Config::STRING{});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS, Config::STRING{});
 
     // Global level — real defaults for effect settings,
     // sentinel for theme-sensitive settings (fallback to hardcoded theme defaults)
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::BLUR_STRENGTH, Hyprlang::FLOAT{GlobalDefaults::BLUR_STRENGTH});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::BLUR_ITERATIONS, Hyprlang::INT{GlobalDefaults::BLUR_ITERATIONS});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::REFRACTION_STRENGTH, Hyprlang::FLOAT{GlobalDefaults::REFRACTION_STRENGTH});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::CHROMATIC_ABERRATION, Hyprlang::FLOAT{GlobalDefaults::CHROMATIC_ABERRATION});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::FRESNEL_STRENGTH, Hyprlang::FLOAT{GlobalDefaults::FRESNEL_STRENGTH});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::SPECULAR_STRENGTH, Hyprlang::FLOAT{GlobalDefaults::SPECULAR_STRENGTH});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::GLASS_OPACITY, Hyprlang::FLOAT{GlobalDefaults::GLASS_OPACITY});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::EDGE_THICKNESS, Hyprlang::FLOAT{GlobalDefaults::EDGE_THICKNESS});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::TINT_COLOR, Hyprlang::INT{GlobalDefaults::TINT_COLOR});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LENS_DISTORTION, Hyprlang::FLOAT{GlobalDefaults::LENS_DISTORTION});
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::BRIGHTNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::CONTRAST, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::SATURATION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::VIBRANCY, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::VIBRANCY_DARKNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::ADAPTIVE_DIM, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::ADAPTIVE_BOOST, SENTINEL_FLOAT);
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::BLUR_STRENGTH, Config::FLOAT{GlobalDefaults::BLUR_STRENGTH});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::BLUR_ITERATIONS, Config::INTEGER{GlobalDefaults::BLUR_ITERATIONS});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::REFRACTION_STRENGTH, Config::FLOAT{GlobalDefaults::REFRACTION_STRENGTH});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::CHROMATIC_ABERRATION, Config::FLOAT{GlobalDefaults::CHROMATIC_ABERRATION});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::FRESNEL_STRENGTH, Config::FLOAT{GlobalDefaults::FRESNEL_STRENGTH});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::SPECULAR_STRENGTH, Config::FLOAT{GlobalDefaults::SPECULAR_STRENGTH});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::GLASS_OPACITY, Config::FLOAT{GlobalDefaults::GLASS_OPACITY});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::EDGE_THICKNESS, Config::FLOAT{GlobalDefaults::EDGE_THICKNESS});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::TINT_COLOR, Config::INTEGER{GlobalDefaults::TINT_COLOR});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LENS_DISTORTION, Config::FLOAT{GlobalDefaults::LENS_DISTORTION});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::BRIGHTNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::CONTRAST, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::SATURATION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::VIBRANCY, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::VIBRANCY_DARKNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::ADAPTIVE_DIM, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::ADAPTIVE_BOOST, Config::FLOAT{SENTINEL_FLOAT});
 
     // Dark theme overrides — all sentinel (inherit from global)
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_BLUR_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_BLUR_ITERATIONS, SENTINEL_INT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_REFRACTION_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_CHROMATIC_ABERRATION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_FRESNEL_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_SPECULAR_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_GLASS_OPACITY, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_EDGE_THICKNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_TINT_COLOR, SENTINEL_INT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_LENS_DISTORTION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_BRIGHTNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_CONTRAST, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_SATURATION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_VIBRANCY, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_VIBRANCY_DARKNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_ADAPTIVE_DIM, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::DARK_ADAPTIVE_BOOST, SENTINEL_FLOAT);
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_BLUR_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::DARK_BLUR_ITERATIONS, Config::INTEGER{SENTINEL_INT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_REFRACTION_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_CHROMATIC_ABERRATION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_FRESNEL_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_SPECULAR_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_GLASS_OPACITY, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_EDGE_THICKNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::DARK_TINT_COLOR, Config::INTEGER{SENTINEL_INT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_LENS_DISTORTION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_BRIGHTNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_CONTRAST, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_SATURATION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_VIBRANCY, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_VIBRANCY_DARKNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_ADAPTIVE_DIM, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::DARK_ADAPTIVE_BOOST, Config::FLOAT{SENTINEL_FLOAT});
 
     // Light theme overrides — all sentinel (inherit from global)
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_BLUR_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_BLUR_ITERATIONS, SENTINEL_INT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_REFRACTION_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_CHROMATIC_ABERRATION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_FRESNEL_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_SPECULAR_STRENGTH, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_GLASS_OPACITY, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_EDGE_THICKNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_TINT_COLOR, SENTINEL_INT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_LENS_DISTORTION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_BRIGHTNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_CONTRAST, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_SATURATION, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_VIBRANCY, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_VIBRANCY_DARKNESS, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_ADAPTIVE_DIM, SENTINEL_FLOAT);
-    HyprlandAPI::addConfigValue(handle, ConfigKeys::LIGHT_ADAPTIVE_BOOST, SENTINEL_FLOAT);
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_BLUR_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::LIGHT_BLUR_ITERATIONS, Config::INTEGER{SENTINEL_INT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_REFRACTION_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_CHROMATIC_ABERRATION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_FRESNEL_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_SPECULAR_STRENGTH, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_GLASS_OPACITY, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_EDGE_THICKNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::LIGHT_TINT_COLOR, Config::INTEGER{SENTINEL_INT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_LENS_DISTORTION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_BRIGHTNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_CONTRAST, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_SATURATION, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_VIBRANCY, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_VIBRANCY_DARKNESS, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_ADAPTIVE_DIM, Config::FLOAT{SENTINEL_FLOAT});
+    addConfigValue<Config::Values::Float>(handle, ConfigKeys::LIGHT_ADAPTIVE_BOOST, Config::FLOAT{SENTINEL_FLOAT});
 
-    // Registered as unscoped because Hyprlang does not dispatch
-    // scoped keyword handlers inside the plugin special category.
+    // Legacy config keyword plus Lua-config callback for custom presets.
     HyprlandAPI::addConfigKeyword(handle, ConfigKeys::PRESET_KEYWORD, handlePresetKeyword, Hyprlang::SHandlerOptions{});
+    HyprlandAPI::addLuaFunction(handle, "hyprglass", "preset", handleLuaPreset);
 }
 
 // ── Config pointer initialization ────────────────────────────────────────────
 
 template <typename T>
-static auto* getStaticPtr(HANDLE handle, const char* key) {
-    return (T* const*)HyprlandAPI::getConfigValue(handle, key)->getDataStaticPtr();
+static auto* getStaticPtr(HANDLE /*handle*/, const char* key) {
+    return reinterpret_cast<T* const*>(Config::mgr()->getConfigValue(key).dataptr);
 }
 
 static void initOverridablePointers(HANDLE handle, SOverridableConfig& layer,
@@ -123,15 +151,15 @@ static void initOverridablePointers(HANDLE handle, SOverridableConfig& layer,
 
 void initConfigPointers(HANDLE handle, SPluginConfig& config) {
     config.enabled       = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::ENABLED);
-    config.defaultTheme  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::DEFAULT_THEME)->getDataStaticPtr();
-    config.defaultPreset = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::DEFAULT_PRESET)->getDataStaticPtr();
+    config.defaultTheme  = getStaticPtr<Config::STRING>(handle, ConfigKeys::DEFAULT_THEME);
+    config.defaultPreset = getStaticPtr<Config::STRING>(handle, ConfigKeys::DEFAULT_PRESET);
 
     config.layersEnabled           = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::LAYERS_ENABLED);
-    config.layersNamespaces        = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::LAYERS_NAMESPACES)->getDataStaticPtr();
-    config.layersExcludeNamespaces = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES)->getDataStaticPtr();
-    config.layersPreset            = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::LAYERS_PRESET)->getDataStaticPtr();
-    config.layersNamespacePresets         = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS)->getDataStaticPtr();
-    config.layersNamespaceMaskThresholds = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS)->getDataStaticPtr();
+    config.layersNamespaces        = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACES);
+    config.layersExcludeNamespaces = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES);
+    config.layersPreset            = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_PRESET);
+    config.layersNamespacePresets         = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS);
+    config.layersNamespaceMaskThresholds = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS);
 
     initOverridablePointers(handle, config.global,
         ConfigKeys::BLUR_STRENGTH, ConfigKeys::BLUR_ITERATIONS,
@@ -349,28 +377,24 @@ void validateConfig() {
 
     const auto& config = g_pGlobalState->config;
 
-    if (config.defaultTheme) {
-        const char* theme = *config.defaultTheme;
-        if (!theme || (std::string_view(theme) != "dark" && std::string_view(theme) != "light")) {
+    const auto theme = readStringConfig(config.defaultTheme);
+    if (theme != "dark" && theme != "light") {
+        HyprlandAPI::addNotificationV2(PHANDLE, {
+            {"text", std::string("[hyprglass] Invalid default_theme '") + std::string(theme) + "', expected 'dark' or 'light'. Falling back to 'dark'."},
+            {"time", (uint64_t)5000},
+            {"color", CHyprColor{1.0, 0.8, 0.2, 1.0}},
+        });
+    }
+
+    const auto preset = readStringConfig(config.defaultPreset);
+    if (!preset.empty() && preset != "default") {
+        const auto& presets = g_pGlobalState->customPresets;
+        if (presets.find(std::string(preset)) == presets.end()) {
             HyprlandAPI::addNotificationV2(PHANDLE, {
-                {"text", std::string("[hyprglass] Invalid default_theme '") + (theme ? theme : "(null)") + "', expected 'dark' or 'light'. Falling back to 'dark'."},
+                {"text", std::string("[hyprglass] Unknown default_preset '") + std::string(preset) + "'. Using 'default' resolution chain."},
                 {"time", (uint64_t)5000},
                 {"color", CHyprColor{1.0, 0.8, 0.2, 1.0}},
             });
-        }
-    }
-
-    if (config.defaultPreset) {
-        const char* preset = *config.defaultPreset;
-        if (preset && preset[0] != '\0' && std::string_view(preset) != "default") {
-            const auto& presets = g_pGlobalState->customPresets;
-            if (presets.find(preset) == presets.end()) {
-                HyprlandAPI::addNotificationV2(PHANDLE, {
-                    {"text", std::string("[hyprglass] Unknown default_preset '") + preset + "'. Using 'default' resolution chain."},
-                    {"time", (uint64_t)5000},
-                    {"color", CHyprColor{1.0, 0.8, 0.2, 1.0}},
-                });
-            }
         }
     }
 }

--- a/src/PluginConfig.hpp
+++ b/src/PluginConfig.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <hyprland/src/config/shared/Types.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <string>
 #include <string_view>
@@ -150,17 +151,23 @@ struct SCustomPreset {
     SPresetValues light;
 };
 
-struct SPluginConfig {
-    Hyprlang::INT* const*   enabled       = nullptr;
-    Hyprlang::STRING const*  defaultTheme  = nullptr;
-    Hyprlang::STRING const*  defaultPreset = nullptr;
+using StringConfigPtr = Config::STRING* const*;
 
-    Hyprlang::INT* const*    layersEnabled           = nullptr;
-    Hyprlang::STRING const*  layersNamespaces        = nullptr;
-    Hyprlang::STRING const*  layersExcludeNamespaces = nullptr;
-    Hyprlang::STRING const*  layersPreset            = nullptr;
-    Hyprlang::STRING const*  layersNamespacePresets         = nullptr;
-    Hyprlang::STRING const*  layersNamespaceMaskThresholds  = nullptr;
+inline std::string_view readStringConfig(StringConfigPtr ptr) {
+    return (ptr && *ptr) ? std::string_view(**ptr) : std::string_view{};
+}
+
+struct SPluginConfig {
+    Hyprlang::INT* const* enabled       = nullptr;
+    StringConfigPtr      defaultTheme  = nullptr;
+    StringConfigPtr      defaultPreset = nullptr;
+
+    Hyprlang::INT* const* layersEnabled                  = nullptr;
+    StringConfigPtr       layersNamespaces               = nullptr;
+    StringConfigPtr       layersExcludeNamespaces        = nullptr;
+    StringConfigPtr       layersPreset                   = nullptr;
+    StringConfigPtr       layersNamespacePresets         = nullptr;
+    StringConfigPtr       layersNamespaceMaskThresholds  = nullptr;
 
     SOverridableConfig global;
     SOverridableConfig dark;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,8 +31,8 @@ static void onNewWindow(PHLWINDOW window) {
 
 static void onCloseWindow(PHLWINDOW window) {
     std::erase_if(g_pGlobalState->decorations, [&window](const auto& decoration) {
-        auto locked = decoration.lock();
-        return !locked || locked->getOwner() == window;
+        auto* deco = decoration.get();
+        return !deco || deco->getOwner() == window;
     });
 }
 
@@ -259,18 +259,23 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
-    for (auto& decoration : g_pGlobalState->decorations) {
-        auto locked = decoration.lock();
-        if (locked) {
-            auto owner = locked->getOwner();
-            if (owner)
-                owner->removeWindowDeco(locked.get());
-        }
-    }
+    if (!g_pGlobalState)
+        return;
 
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassPassElement");
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassLayerPassElement");
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassLayerCompositeElement");
+
+    for (auto& decoration : g_pGlobalState->decorations) {
+        if (auto* deco = decoration.get())
+            HyprlandAPI::removeWindowDecoration(PHANDLE, deco);
+    }
+    g_pGlobalState->decorations.clear();
+
+    if (g_pGlobalState->renderLayerHook) {
+        HyprlandAPI::removeFunctionHook(PHANDLE, g_pGlobalState->renderLayerHook);
+        g_pGlobalState->renderLayerHook = nullptr;
+    }
 
     g_pGlobalState->layerSurfaces.clear();
     g_pGlobalState->shaderManager.destroy();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,13 +39,12 @@ static void onCloseWindow(PHLWINDOW window) {
 // ── Layer surface support ────────────────────────────────────────────────────
 
 // Parse comma-separated config string into a set of trimmed values.
-static void parseCommaSeparated(Hyprlang::STRING const* configPtr, std::unordered_set<std::string>& out) {
+static void parseCommaSeparated(StringConfigPtr configPtr, std::unordered_set<std::string>& out) {
     out.clear();
-    if (!configPtr) return;
-    const char* raw = *configPtr;
-    if (!raw || raw[0] == '\0') return;
+    const auto raw = readStringConfig(configPtr);
+    if (raw.empty()) return;
 
-    std::istringstream stream(raw);
+    std::istringstream stream{std::string(raw)};
     std::string token;
     while (std::getline(stream, token, ',')) {
         auto start = token.find_first_not_of(" \t");
@@ -57,12 +56,11 @@ static void parseCommaSeparated(Hyprlang::STRING const* configPtr, std::unordere
 
 // Parse comma-separated "key<sep>value" pairs. The callback receives (key, valueStr) for each pair.
 template <typename Fn>
-static void parseKeyValuePairs(Hyprlang::STRING const* configPtr, char separator, Fn&& callback) {
-    if (!configPtr) return;
-    const char* raw = *configPtr;
-    if (!raw || raw[0] == '\0') return;
+static void parseKeyValuePairs(StringConfigPtr configPtr, char separator, Fn&& callback) {
+    const auto raw = readStringConfig(configPtr);
+    if (raw.empty()) return;
 
-    std::istringstream stream(raw);
+    std::istringstream stream{std::string(raw)};
     std::string token;
     while (std::getline(stream, token, ',')) {
         auto sepPos = token.rfind(separator);
@@ -114,9 +112,9 @@ static bool shouldGlassLayer(PHLLS layerSurface) {
     return include.contains(ns);
 }
 
-using renderLayerFn = void (*)(CHyprRenderer*, PHLLS, PHLMONITOR, const Time::steady_tp&, bool, bool);
+using renderLayerFn = void (*)(Render::IHyprRenderer*, PHLLS, PHLMONITOR, const Time::steady_tp&, bool, bool);
 
-static void hkRenderLayer(CHyprRenderer* thisptr, PHLLS layerSurface, PHLMONITOR monitor,
+static void hkRenderLayer(Render::IHyprRenderer* thisptr, PHLLS layerSurface, PHLMONITOR monitor,
                            const Time::steady_tp& now, bool popups, bool lockscreen) {
     const auto& config = g_pGlobalState->config;
 
@@ -208,6 +206,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     static auto onPreConfigReload = Event::bus()->m_events.config.preReload.listen([&]() { clearPendingPresets(); });
 
     static auto onConfigReloaded = Event::bus()->m_events.config.reloaded.listen([&]() {
+        initConfigPointers(PHANDLE, g_pGlobalState->config);
         commitPendingPresets();
         validateConfig();
         parseLayerNamespaceFilters();
@@ -219,7 +218,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     // Shadows must be enabled for the glass effect to sample the correct background.
     // Force-enable if the user has disabled them.
-    static auto* const PSHADOWENABLED = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("decoration:shadow:enabled");
+    const auto shadowEnabled = Config::mgr()->getConfigValue("decoration:shadow:enabled");
+    auto* const PSHADOWENABLED = reinterpret_cast<Hyprlang::INT* const*>(shadowEnabled.dataptr);
     if (PSHADOWENABLED && !**PSHADOWENABLED) {
         HyprlandAPI::invokeHyprctlCommand("keyword", "decoration:shadow:enabled true");
     }
@@ -233,7 +233,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // Hook renderLayer for layer surface glass support
     auto renderLayerMatches = HyprlandAPI::findFunctionsByName(PHANDLE, "renderLayer");
     for (const auto& match : renderLayerMatches) {
-        // Match the overload: CHyprRenderer::renderLayer(PHLLS, PHLMONITOR, steady_tp, bool, bool)
+        // Match the overload: Render::IHyprRenderer::renderLayer(PHLLS, PHLMONITOR, steady_tp, bool, bool)
         if (match.demangled.contains("renderLayer") && match.demangled.contains("LayerSurface")) {
             g_pGlobalState->renderLayerHook = HyprlandAPI::createFunctionHook(PHANDLE, match.address, (void*)hkRenderLayer);
             if (g_pGlobalState->renderLayerHook)
@@ -251,6 +251,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     }
 
     HyprlandAPI::reloadConfig();
+    initConfigPointers(PHANDLE, g_pGlobalState->config);
     validateConfig();
     parseLayerNamespaceFilters();
 


### PR DESCRIPTION
I really love this project, and it was painful to see it break on Hyprland 0.55. So I spent some time debugging it and tried to get it working again.  

### What changed

 - Move plugin config registration to addConfigValueV2                                                                
 - Read config values through Config::mgr()->getConfigValue(...).dataptr                                              
 - Re-initialize cached config pointers after config reload                                                           
 - Update custom render pass elements to the current pass API                                                         
 - Use SP<Render::IFramebuffer> for framebuffer ownership/redirects                                                   
 - Add guards for invalid/empty/non-finite layer geometry before damage/scissor calls                                 
 - Fix layer geometry handling so sampling uses monitor-local framebuffer pixels                                      
 - Keep existing hyprland.conf syntax working                                                                         
 - Add Lua preset registration via hl.plugin.hyprglass.preset(...)          
 
### Notes

 I intentionally kept addConfigKeyword for the preset keyword because I could not find a replacement V2 keyword API in the current Hyprland headers. 

### Tested
 - make clean && make                                                                                                 
 - Plugin unload/load on Hyprland 0.55.2                                                                              
 - hyprctl configerrors                                                                                               
 - Verified:                                                                                                          
     - plugin:hyprglass:enabled = 1                                                                                   
     - plugin:hyprglass:layers:enabled = 1                                                                            
 - Checked recent journal logs for crash/pixman/shader errors     