### PR TITLE
fix: support legacy string config values

### DIFF
--- a/src/PluginConfig.cpp
+++ b/src/PluginConfig.cpp
@@ -117,6 +117,11 @@ static auto* getStaticPtr(HANDLE /*handle*/, const char* key) {
     return reinterpret_cast<T* const*>(Config::mgr()->getConfigValue(key).dataptr);
 }
 
+static StringConfigPtr getStringPtr(HANDLE /*handle*/, const char* key) {
+    const auto value = Config::mgr()->getConfigValue(key);
+    return {.dataptr = value.dataptr, .type = value.type};
+}
+
 static void initOverridablePointers(HANDLE handle, SOverridableConfig& layer,
                                     const char* blurStrength, const char* blurIterations,
                                     const char* refractionStrength, const char* chromaticAberration,
@@ -148,15 +153,15 @@ static void initOverridablePointers(HANDLE handle, SOverridableConfig& layer,
 
 void initConfigPointers(HANDLE handle, SPluginConfig& config) {
     config.enabled       = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::ENABLED);
-    config.defaultTheme  = getStaticPtr<Config::STRING>(handle, ConfigKeys::DEFAULT_THEME);
-    config.defaultPreset = getStaticPtr<Config::STRING>(handle, ConfigKeys::DEFAULT_PRESET);
+    config.defaultTheme  = getStringPtr(handle, ConfigKeys::DEFAULT_THEME);
+    config.defaultPreset = getStringPtr(handle, ConfigKeys::DEFAULT_PRESET);
 
     config.layersEnabled           = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::LAYERS_ENABLED);
-    config.layersNamespaces        = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACES);
-    config.layersExcludeNamespaces = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES);
-    config.layersPreset            = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_PRESET);
-    config.layersNamespacePresets         = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS);
-    config.layersNamespaceMaskThresholds = getStaticPtr<Config::STRING>(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS);
+    config.layersNamespaces        = getStringPtr(handle, ConfigKeys::LAYERS_NAMESPACES);
+    config.layersExcludeNamespaces = getStringPtr(handle, ConfigKeys::LAYERS_EXCLUDE_NAMESPACES);
+    config.layersPreset            = getStringPtr(handle, ConfigKeys::LAYERS_PRESET);
+    config.layersNamespacePresets         = getStringPtr(handle, ConfigKeys::LAYERS_NAMESPACE_PRESETS);
+    config.layersNamespaceMaskThresholds = getStringPtr(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_THRESHOLDS);
 
     initOverridablePointers(handle, config.global,
         ConfigKeys::BLUR_STRENGTH, ConfigKeys::BLUR_ITERATIONS,

--- a/src/PluginConfig.hpp
+++ b/src/PluginConfig.hpp
@@ -4,6 +4,7 @@
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <string>
 #include <string_view>
+#include <typeinfo>
 #include <unordered_map>
 
 inline constexpr std::string_view CONFIG_PREFIX = "plugin:hyprglass:";
@@ -151,23 +152,39 @@ struct SCustomPreset {
     SPresetValues light;
 };
 
-using StringConfigPtr = Config::STRING* const*;
+struct StringConfigPtr {
+    void* const*          dataptr = nullptr;
+    const std::type_info* type    = nullptr;
+};
 
-inline std::string_view readStringConfig(StringConfigPtr ptr) {
-    return (ptr && *ptr) ? std::string_view(**ptr) : std::string_view{};
+inline std::string_view readStringConfig(const StringConfigPtr& ptr) {
+    if (!ptr.dataptr || !ptr.type)
+        return {};
+
+    if (*ptr.type == typeid(Config::STRING)) {
+        const auto* value = *reinterpret_cast<Config::STRING* const*>(ptr.dataptr);
+        return value ? std::string_view(*value) : std::string_view{};
+    }
+
+    if (*ptr.type == typeid(Hyprlang::STRING)) {
+        const auto value = *reinterpret_cast<Hyprlang::STRING const*>(ptr.dataptr);
+        return value ? std::string_view(value) : std::string_view{};
+    }
+
+    return {};
 }
 
 struct SPluginConfig {
     Hyprlang::INT* const* enabled       = nullptr;
-    StringConfigPtr      defaultTheme  = nullptr;
-    StringConfigPtr      defaultPreset = nullptr;
+    StringConfigPtr      defaultTheme;
+    StringConfigPtr      defaultPreset;
 
     Hyprlang::INT* const* layersEnabled                  = nullptr;
-    StringConfigPtr       layersNamespaces               = nullptr;
-    StringConfigPtr       layersExcludeNamespaces        = nullptr;
-    StringConfigPtr       layersPreset                   = nullptr;
-    StringConfigPtr       layersNamespacePresets         = nullptr;
-    StringConfigPtr       layersNamespaceMaskThresholds  = nullptr;
+    StringConfigPtr       layersNamespaces;
+    StringConfigPtr       layersExcludeNamespaces;
+    StringConfigPtr       layersPreset;
+    StringConfigPtr       layersNamespacePresets;
+    StringConfigPtr       layersNamespaceMaskThresholds;
 
     SOverridableConfig global;
     SOverridableConfig dark;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,8 +256,10 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::reloadConfig();
     initConfigPointers(PHANDLE, g_pGlobalState->config);
-    validateConfig();
+    commitPendingPresets();
     parseLayerNamespaceFilters();
+    commitPendingLayers();
+    validateConfig();
 
     return {std::string(PLUGIN_NAME), std::string(PLUGIN_DESCRIPTION), std::string(PLUGIN_AUTHOR), std::string(PLUGIN_VERSION)};
 }


### PR DESCRIPTION
 Fixes #32

## Summary

This fixes legacy `hyprland.conf` string config handling after the Hyprland 0.55 compatibility changes.

Some plugin string values can come back as `Config::STRING`, while legacy config paths may still expose them as `Hyprlang::STRING`. The plugin was assuming `Config::STRING` for all string options, which made some values look empty or invalid.

Also fixes an initialization-order warning where `default_preset = clear` could be reported as unknown before presets were committed during initial plugin load.

## What changed

- Store the config value type together with string config pointers
- Read both `Config::STRING` and `Hyprlang::STRING` safely
- Apply this to:
  - `default_theme`
  - `default_preset`
  - `layers:namespaces`
  - `layers:exclude_namespaces`
  - `layers:preset`
  - `layers:namespace_presets`
  - `layers:namespace_mask_thresholds`

## Why

This should fix cases where legacy `.conf` users see warnings like `default_theme` not being set, or where string-based options do not apply correctly.

It should also avoid crashes when setting string layer options such as `layers:namespaces`.

## Tested
Done
