### PR TITLE
fix: keep layer mask threshold stable during fade

### DIFF
--- a/src/GlassLayerSurface.cpp
+++ b/src/GlassLayerSurface.cpp
@@ -251,6 +251,11 @@ void CGlassLayerSurface::compositeAndRestore(PHLMONITOR monitor, float alpha) {
     if (threshIt != g_pGlobalState->layerNamespaceMaskThresholds.end())
         maskThreshold = threshIt->second;
 
+    // The temp FBO stores the layer after Hyprland applies fade alpha. Keep
+    // mask_threshold relative to the layer's content alpha, otherwise fade-out
+    // makes the mask fall below threshold early and the glass blinks off.
+    maskThreshold *= std::clamp(alpha, 0.0f, 1.0f);
+
     GlassRenderer::SMaskInfo maskInfo{
         .textureId         = m_surfaceTempFramebuffer->getTexture()->m_texID,
         .target            = GL_TEXTURE_2D,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,21 @@
 
 #include <sstream>
 
+static void clearLayerGlassOnClose(PHLLS layerSurface) {
+    if (!g_pGlobalState || !layerSurface)
+        return;
+
+    // Drop cached layer glass immediately. Otherwise the previous glass output
+    // can remain in the damage history while Hyprland switches to its close
+    // snapshot path, showing stale/black pixels for a frame.
+    std::erase_if(g_pGlobalState->layerSurfaces, [&](const auto& pair) {
+        return pair.first == layerSurface.get() || pair.second->getLayerSurface() == layerSurface;
+    });
+
+    if (auto monitor = layerSurface->m_monitor.lock())
+        g_pHyprRenderer->damageMonitor(monitor);
+}
+
 static void onNewWindow(PHLWINDOW window) {
     if (std::ranges::any_of(window->m_windowDecorations,
                             [](const auto& decoration) { return decoration->getDisplayName() == "HyprGlass"; }))
@@ -118,6 +133,15 @@ static void hkRenderLayer(Render::IHyprRenderer* thisptr, PHLLS layerSurface, PH
                            const Time::steady_tp& now, bool popups, bool lockscreen) {
     const auto& config = g_pGlobalState->config;
 
+    // Hyprland renders closing layers from snapshots. Do not inject the glass
+    // pipeline while that snapshot is being captured: the snapshot framebuffer
+    // starts transparent/black, so sampling it as a background can bake a black
+    // rectangle into the fade-out snapshot.
+    if (g_pHyprRenderer->m_bRenderingSnapshot) {
+        ((renderLayerFn)g_pGlobalState->renderLayerHook->m_original)(thisptr, layerSurface, monitor, now, popups, lockscreen);
+        return;
+    }
+
     // Prune dead layer surfaces whose weak_ptr has expired (layer was destroyed
     // but never got a replacement at the same raw pointer address)
     std::erase_if(g_pGlobalState->layerSurfaces, [](const auto& pair) {
@@ -135,6 +159,11 @@ static void hkRenderLayer(Render::IHyprRenderer* thisptr, PHLLS layerSurface, PH
             it->second = std::make_shared<CGlassLayerSurface>(layerSurface);
         } else if (it == layerStates.end()) {
             it = layerStates.emplace(rawPtr, std::make_shared<CGlassLayerSurface>(layerSurface)).first;
+        }
+
+        if (layerSurface->m_fadingOut) {
+            ((renderLayerFn)g_pGlobalState->renderLayerHook->m_original)(thisptr, layerSurface, monitor, now, popups, lockscreen);
+            return;
         }
 
         float alpha = layerSurface->m_alpha->value();
@@ -185,6 +214,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     static auto onOpen = Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(w); });
 
     static auto onClose = Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); });
+
+    static auto onLayerClosed = Event::bus()->m_events.layer.closed.listen([&](PHLLS layerSurface) { clearLayerGlassOnClose(layerSurface); });
 
     // Z-order / visibility changes invalidate layer glass caches on the affected monitor only.
     // Per-monitor to avoid triggering re-samples on idle monitors (feedback loop).


### PR DESCRIPTION
Fixes #35 

## Summary

This fixes a black flash / blink that can happen when a glassed layer surface closes.

The issue was caused by stale layer glass state interacting with Hyprland's
 layer close snapshot path. When a layer closes, Hyprland captures a snapshot and then fades that snapshot out. If HyprGlass keeps using the previous layer glass cache during that transition, stale or black pixels can remain visible for a frame.

## Changes

   - Clear the cached glass state for a layer as soon as it closes
   - Damage the affected monitor after clearing the layer cache
   - Skip the HyprGlass layer pipeline while Hyprland is capturing close snapshots
   - Let fading-out layers use Hyprland's native snapshot render path
   - Scale `namespace_mask_thresholds` by the current layer alpha during compositing

   ## Tested

   - `make clean && make`
   - Plugin unload/load
   - `hyprctl reload`
   - `hyprctl configerrors`
   - Verified with `vicinae` layer open/close: black blink no longer occurs
