### PR TITLE
fix: force xray property to false for windows with HyprGlass decoration

### DIFF
--- a/src/GlassDecoration.cpp
+++ b/src/GlassDecoration.cpp
@@ -95,6 +95,9 @@ void CGlassDecoration::draw(PHLMONITOR monitor, float const& alpha) {
 
     const auto window = m_window.lock();
     if (window) {
+        if (window->m_ruleApplicator)
+            window->m_ruleApplicator->xray().set(false, Desktop::Types::PRIORITY_SET_PROP);
+
         const auto workspace = window->m_workspace;
 
         const bool wsAnimating = workspace && !window->m_pinned && workspace->m_renderOffset->isBeingAnimated();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
 #include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/desktop/rule/windowRule/WindowRuleApplicator.hpp>
 
 #include <sstream>
 
@@ -42,6 +43,10 @@ static void onNewWindow(PHLWINDOW window) {
     g_pGlobalState->decorations.emplace_back(decoration);
     decoration->m_self = decoration;
     HyprlandAPI::addWindowDecoration(PHANDLE, window, std::move(decoration));
+
+    if (window->m_ruleApplicator) {
+        window->m_ruleApplicator->xray().set(false, Desktop::Types::PRIORITY_SET_PROP);
+    }
 }
 
 static void onCloseWindow(PHLWINDOW window) {
@@ -313,6 +318,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
         HyprlandAPI::removeFunctionHook(PHANDLE, g_pGlobalState->renderLayerHook);
         g_pGlobalState->renderLayerHook = nullptr;
     }
+
 
     g_pGlobalState->layerSurfaces.clear();
     g_pGlobalState->shaderManager.destroy();


### PR DESCRIPTION
# Description

This PR fixes an issue where the acrylic/reflection glass effect of HyprGlass fails when the `xray` option for blur is active in Hyprland. 

In Hyprland, enabling the `xray` option on blur makes blurred surfaces bypass windows directly beneath them to show/blur the wallpaper instead. While this is optimized for standard window blur, it breaks the key feature of `HyprGlass` (which relies on showing and blurring the windows immediately behind the active glass surface to achieve a realistic glass/acrylic look).

This fix explicitly disables the `xray` property on the rule applicator of any window that has the `HyprGlass` decoration, ensuring that the glass effect always renders the content directly underneath it.

## Key Changes

- **`src/main.cpp`**: 
  - Updated `onNewWindow()` to disable `xray` on the window's rule applicator (`m_ruleApplicator->xray().set(false, ...)`) immediately when a window is decorated with `HyprGlass`.
- **`src/GlassDecoration.cpp`**: 
  - Added a fallback check in `CGlassDecoration::draw()` to ensure `xray` is kept disabled on the rule applicator during draw cycles.

## Disclaimer
AI-assisted fix, manually reviewed and verified. Suggestions for improvement are welcome!