### PR TITLE
fix: keep glass effect during layer close/fade-out animations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,10 +162,10 @@ static void hkRenderLayer(Render::IHyprRenderer* thisptr, PHLLS layerSurface, PH
             it = layerStates.emplace(rawPtr, std::make_shared<CGlassLayerSurface>(layerSurface)).first;
         }
 
-        if (!layerSurface->m_mapped) {
-            ((renderLayerFn)g_pGlobalState->renderLayerHook->m_original)(thisptr, layerSurface, monitor, now, popups, lockscreen);
-            return;
-        }
+        // Allow glass to keep rendering during close/fade-out animations.
+        // sampleAndRedirect() already handles !m_mapped by reusing the cached
+        // blurred background instead of re-sampling, so the glass effect stays
+        // visible for the full duration of the exit animation.
 
         float alpha = layerSurface->alpha().getTotal();
         if (alpha < 0.001f) {


### PR DESCRIPTION
When a layer surface (like a sidebar or panel) starts closing, the glass effect was snapping off instantly at the very first frame of the exit animation, even while the slide/fade was still playing.

The issue was the `!m_mapped` early-exit in `hkRenderLayer`. Hyprland sets `m_mapped = false` the moment a layer begins closing — before the animation finishes — so the glass pipeline was being skipped entirely.

The fix is simply removing that early-exit. `sampleAndRedirect()` already handles the unmapped case correctly by reusing the cached blurred background instead of re-sampling, so the glass stays visible for the full animation.

The `m_bRenderingSnapshot` guard is left intact.

Tested with a Quickshell sidebar (slide-right exit animation). Glass effect now stays consistent throughout the full close animation with no artifacts.