### PR TITLE
layers: invalidate the cached backdrop on drag, open and close

### DIFF
--- a/src/GlassLayerSurface.cpp
+++ b/src/GlassLayerSurface.cpp
@@ -114,6 +114,27 @@ void CGlassLayerSurface::damageIfMoved() {
     }
 }
 
+void CGlassLayerSurface::requestResampleIfOn(PHLMONITOR monitor, int frames) {
+    const auto layerSurface = m_layerSurface.lock();
+    if (!layerSurface || layerSurface->m_monitor.lock() != monitor)
+        return;
+
+    m_pendingResampleFrames = std::max(m_pendingResampleFrames, frames);
+
+    const auto position = layerSurface->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
+    const auto size     = layerSurface->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
+    if (size.x <= 0.0 || size.y <= 0.0 ||
+        !std::isfinite(position.x) || !std::isfinite(position.y) ||
+        !std::isfinite(size.x) || !std::isfinite(size.y))
+        return;
+
+    auto box = CBox{position, size};
+    const float scale = monitor ? monitor->m_scale : 1.0f;
+    box.expand(GlassRenderer::SAMPLE_PADDING_PX / scale).noNegativeSize();
+    if (box.w > 0.0 && box.h > 0.0)
+        g_pHyprRenderer->damageBox(box);
+}
+
 void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     auto& shaderManager = g_pGlobalState->shaderManager;
     shaderManager.initializeIfNeeded();
@@ -148,9 +169,19 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     const bool isDragging = g_layoutManager && g_layoutManager->dragController() &&
                             g_layoutManager->dragController()->mode() != MBIND_INVALID;
 
+    const bool pendingResample = m_pendingResampleFrames > 0;
+    if (pendingResample) {
+        --m_pendingResampleFrames;
+        auto box = CBox{layerSurface->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT),
+                        layerSurface->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT)};
+        box.expand(GlassRenderer::SAMPLE_PADDING_PX / (monitor ? monitor->m_scale : 1.0f)).noNegativeSize();
+        if (box.w > 0.0 && box.h > 0.0)
+            g_pHyprRenderer->damageBox(box);
+    }
+
     const bool backgroundChanged = !m_hasCachedSample ||
                                    currentGeneration != m_lastSceneGeneration ||
-                                   isAnimating || isDragging;
+                                   isAnimating || isDragging || pendingResample;
 
     if (!layerSurface->m_mapped) {
         // During fade-out, re-sampling captures stale pixels. Reuse cached sample.

--- a/src/GlassLayerSurface.cpp
+++ b/src/GlassLayerSurface.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cmath>
 #include <hyprland/src/desktop/Workspace.hpp>
+#include <hyprland/src/layout/LayoutManager.hpp>
+#include <hyprland/src/layout/supplementary/DragController.hpp>
 #include <GLES3/gl32.h>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Renderer.hpp>
@@ -143,9 +145,12 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
                              layerSurface->sizeAnimation()->isBeingAnimated() ||
                              layerSurface->alpha()[Desktop::View::LS_ALPHA_FADE]->isBeingAnimated() ||
                              (activeWs && activeWs->m_renderOffset->isBeingAnimated());
+    const bool isDragging = g_layoutManager && g_layoutManager->dragController() &&
+                            g_layoutManager->dragController()->mode() != MBIND_INVALID;
+
     const bool backgroundChanged = !m_hasCachedSample ||
                                    currentGeneration != m_lastSceneGeneration ||
-                                   isAnimating;
+                                   isAnimating || isDragging;
 
     if (!layerSurface->m_mapped) {
         // During fade-out, re-sampling captures stale pixels. Reuse cached sample.

--- a/src/GlassLayerSurface.hpp
+++ b/src/GlassLayerSurface.hpp
@@ -19,10 +19,13 @@ class CGlassLayerSurface {
 
     void damageIfMoved();
 
+    void requestResampleIfOn(PHLMONITOR monitor, int frames = 4);
+
     [[nodiscard]] PHLLS getLayerSurface() const;
 
   private:
     PHLLSREF     m_layerSurface;
+    int          m_pendingResampleFrames = 0;
     SP<Render::IFramebuffer> m_sampleFramebuffer;
     SP<Render::IFramebuffer> m_surfaceTempFramebuffer;
     Vector2D     m_samplePaddingRatio;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,10 @@ static void onCloseWindow(PHLWINDOW window) {
         auto* deco = decoration.get();
         return !deco || deco->getOwner() == window;
     });
+
+    if (window)
+        if (auto mon = window->m_monitor.lock())
+            g_pGlobalState->bumpSceneGeneration(mon);
 }
 
 // ── Layer surface support ────────────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,17 @@ static void onNewWindow(PHLWINDOW window) {
     HyprlandAPI::addWindowDecoration(PHANDLE, window, std::move(decoration));
 }
 
+static void invalidateGlassLayers(PHLMONITOR monitor, int frames = 4) {
+    if (!monitor)
+        return;
+
+    g_pGlobalState->bumpSceneGeneration(monitor);
+
+    for (auto& [_, glass] : g_pGlobalState->layerSurfaces)
+        if (glass)
+            glass->requestResampleIfOn(monitor, frames);
+}
+
 static void onCloseWindow(PHLWINDOW window) {
     std::erase_if(g_pGlobalState->decorations, [&window](const auto& decoration) {
         auto* deco = decoration.get();
@@ -52,8 +63,7 @@ static void onCloseWindow(PHLWINDOW window) {
     });
 
     if (window)
-        if (auto mon = window->m_monitor.lock())
-            g_pGlobalState->bumpSceneGeneration(mon);
+        invalidateGlassLayers(window->m_monitor.lock(), 90);
 }
 
 // ── Layer surface support ────────────────────────────────────────────────────
@@ -236,7 +246,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     g_pGlobalState = std::make_unique<SGlobalState>();
 
-    static auto onOpen = Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(w); });
+    static auto onOpen = Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(w); if (w) invalidateGlassLayers(w->m_monitor.lock(), 90); });
 
     static auto onClose = Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); });
 
@@ -245,7 +255,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // Z-order / visibility changes invalidate layer glass caches on the affected monitor only.
     // Per-monitor to avoid triggering re-samples on idle monitors (feedback loop).
     auto bumpWindowMonitor = [&](PHLWINDOW w) {
-        if (w) if (auto mon = w->m_monitor.lock()) g_pGlobalState->bumpSceneGeneration(mon);
+        if (w) invalidateGlassLayers(w->m_monitor.lock());
     };
     static auto onWindowActive = Event::bus()->m_events.window.active.listen(
         [=](PHLWINDOW w, Desktop::eFocusReason) { bumpWindowMonitor(w); });
@@ -255,7 +265,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         [=](PHLWINDOW w, PHLWORKSPACE) { bumpWindowMonitor(w); });
     static auto onWorkspaceActive = Event::bus()->m_events.workspace.active.listen(
         [&](PHLWORKSPACE ws) {
-            if (ws) if (auto mon = ws->m_monitor.lock()) g_pGlobalState->bumpSceneGeneration(mon);
+            if (ws) invalidateGlassLayers(ws->m_monitor.lock());
         });
 
     // Clear pending presets/layers before config re-parse, commit after


### PR DESCRIPTION
Glass on a layer holds a stale backdrop in three cases. While a window is dragged under it, it only catches up when the drag ends. When a window opens or closes under it, it keeps showing the old frame until something else happens, like switching focus.

The scene generation is bumped by `CGlassDecoration` when a window moves, but that decoration only exists on glassed windows. With glass on layers only, nothing bumps it during a drag. Open and close bump nothing at all.

Bumping on the event alone is not enough either. The sample runs before the opening window has been drawn, and before the closing one is gone, so the wrong frame is cached and nothing invalidates it again.

This re-samples while a drag is in progress, and holds the layer dirty for a number of frames after open and close, damaging it each time so the frames keep coming. Open and close animate and get 90 frames, focus and workspace changes are immediate and get 4. The cache is untouched the rest of the time. `MBIND_RESIZE` covered too.

The frame counts are a rough stand-in for the length of the open and close animation. Tying it to the animation itself would be better, I could not find an accessor for that on 0.56.

Tested on Hyprland 0.56.2, glass on a dock layer only. Related to #59.
