### PR TITLE
fix: own event listeners in plugin state so unload unregisters them

### DIFF
--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -9,6 +9,7 @@
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/SharedDefs.hpp>
+#include <hyprutils/signal/Listener.hpp>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -18,6 +19,10 @@
 class CGlassDecoration;
 
 struct SGlobalState {
+    // Event listeners are owned here so PLUGIN_EXIT unregisters them. Static
+    // listeners outlived the plugin and fired after unload -> SEGV on reload.
+    std::vector<Hyprutils::Signal::CHyprSignalListener> listeners;
+
     std::vector<WP<CGlassDecoration>> decorations;
     CShaderManager                    shaderManager;
     SPluginConfig                     config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,41 +232,43 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     g_pGlobalState = std::make_unique<SGlobalState>();
 
-    static auto onOpen = Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(w); });
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(w); }));
 
-    static auto onClose = Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); });
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.window.close.listen([&](PHLWINDOW w) { onCloseWindow(w); }));
 
-    static auto onLayerClosed = Event::bus()->m_events.layer.closed.listen([&](PHLLS layerSurface) { clearLayerGlassOnClose(layerSurface); });
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.layer.closed.listen([&](PHLLS layerSurface) { clearLayerGlassOnClose(layerSurface); }));
 
     // Z-order / visibility changes invalidate layer glass caches on the affected monitor only.
     // Per-monitor to avoid triggering re-samples on idle monitors (feedback loop).
     auto bumpWindowMonitor = [&](PHLWINDOW w) {
         if (w) if (auto mon = w->m_monitor.lock()) g_pGlobalState->bumpSceneGeneration(mon);
     };
-    static auto onWindowActive = Event::bus()->m_events.window.active.listen(
-        [=](PHLWINDOW w, Desktop::eFocusReason) { bumpWindowMonitor(w); });
-    static auto onWindowFullscreen = Event::bus()->m_events.window.fullscreen.listen(
-        [=](PHLWINDOW w) { bumpWindowMonitor(w); });
-    static auto onWindowMoveToWorkspace = Event::bus()->m_events.window.moveToWorkspace.listen(
-        [=](PHLWINDOW w, PHLWORKSPACE) { bumpWindowMonitor(w); });
-    static auto onWorkspaceActive = Event::bus()->m_events.workspace.active.listen(
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.window.active.listen(
+        [=](PHLWINDOW w, Desktop::eFocusReason) { bumpWindowMonitor(w); }));
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.window.fullscreen.listen(
+        [=](PHLWINDOW w) { bumpWindowMonitor(w); }));
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.window.moveToWorkspace.listen(
+        [=](PHLWINDOW w, PHLWORKSPACE) { bumpWindowMonitor(w); }));
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.workspace.active.listen(
         [&](PHLWORKSPACE ws) {
             if (ws) if (auto mon = ws->m_monitor.lock()) g_pGlobalState->bumpSceneGeneration(mon);
-        });
+        }));
 
     // Clear pending presets/layers before config re-parse, commit after
-    static auto onPreConfigReload = Event::bus()->m_events.config.preReload.listen([&]() {
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.config.preReload.listen([&]() {
         clearPendingPresets();
         clearPendingLayers();
-    });
+    }));
 
-    static auto onConfigReloaded = Event::bus()->m_events.config.reloaded.listen([&]() {
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.config.reloaded.listen([&]() {
+        if (!g_pGlobalState)
+            return;
         initConfigPointers(PHANDLE, g_pGlobalState->config);
         commitPendingPresets();
         parseLayerNamespaceFilters();
         commitPendingLayers(); // merge Lua layer() calls on top of string config
         validateConfig();
-    });
+    }));
 
 
     registerConfig(PHANDLE);
@@ -319,6 +321,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 APICALL EXPORT void PLUGIN_EXIT() {
     if (!g_pGlobalState)
         return;
+
+    g_pGlobalState->listeners.clear();
 
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassPassElement");
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassLayerPassElement");


### PR DESCRIPTION
## Problem

The event bus listeners in `PLUGIN_INIT` are function-local `static` variables, so they outlive `PLUGIN_EXIT`. After `hyprctl plugin unload`, the next config reload still fires the `config.reloaded` handler, which calls `initConfigPointers(PHANDLE, g_pGlobalState->config)` on an already-destroyed `g_pGlobalState` and crashes the compositor.

Crash report (Hyprland 0.56.2 / hyprglass v0.7.0):

```
Hyprland received signal 11(SEGV)
#4 hyprglass.so(_Z18initConfigPointersPvR13SPluginConfig+0x1b)
#5 hyprglass.so(+0x2ae48)                      <- config.reloaded lambda
#6 libhyprutils.so.13(CSignalListener::emitInternal)
#8 Hyprland(Config::Legacy::CConfigManager::postConfigReload)
#9 Hyprland(Config::Legacy::CConfigManager::reload)
```

Note that hyprglass does not appear in the crash report's plugin list: the plugin had been unloaded, but its listeners were still registered.

## Reproduction

```bash
hyprctl plugin load /path/to/hyprglass.so
hyprctl plugin unload /path/to/hyprglass.so
hyprctl reload        # SIGSEGV
```

## Fix

- Store the listeners in `SGlobalState` (`std::vector<CHyprSignalListener>`), so their lifetime is tied to the plugin instance.
- Clear them explicitly at the start of `PLUGIN_EXIT`, before render state is torn down.
- Add a `g_pGlobalState` guard in the `config.reloaded` handler as a belt-and-braces check.

## Verification

Tested on Hyprland 0.56.2 (`efb5099`) in a nested instance (`Hyprland -c test.conf` inside a running session):

- load → unload → reload: no crash (crashed before the patch)
- two load/unload cycles → reload: OK
- hot-load via `plugin =` line + reload: OK
- 5 consecutive reloads with the plugin loaded: OK
- final unload → reload: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
