### PR TITLE
feat: x-ray — sample the pre-window frame (wallpaper only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(basename $(CXX)),g++)
 endif
 
 TARGET = hyprglass.so
-SOURCES = src/main.cpp src/GlassDecoration.cpp src/GlassPassElement.cpp src/GlassRenderer.cpp src/GlassLayerSurface.cpp src/GlassLayerPassElement.cpp src/GlassLayerCompositeElement.cpp src/PluginConfig.cpp src/ShaderManager.cpp
+SOURCES = src/main.cpp src/GlassDecoration.cpp src/GlassPassElement.cpp src/GlassRenderer.cpp src/GlassLayerSurface.cpp src/GlassLayerPassElement.cpp src/GlassLayerCompositeElement.cpp src/GlassSnapshotElement.cpp src/PluginConfig.cpp src/ShaderManager.cpp
 OBJ = $(SOURCES:.cpp=.o)
 HEADERS = $(wildcard src/*.hpp)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ if hl.plugin.hyprglass then
     })
 
     -- Layer surfaces: each call whitelists the namespace and configures it
-    hg.layer("waybar", { preset = "subtle", mask_threshold = 0.05 })
+    hg.layer("waybar", { preset = "subtle", mask_threshold = 0.05, xray = true })
     hg.layer("swaync")
     hg.layer("quickshell:bezel", { preset = "ui", mask_threshold = 0.3 })
     hg.layer("debug-panel", { exclude = true })
@@ -130,6 +130,7 @@ plugin:hyprglass {
 |---|---|---|---|
 | `enabled` | bool | `true` (`1` in .conf) | Enable/disable the effect globally. Per-window tags override this. |
 | `manage_window_blur` | bool | `true` (`1` in .conf) | Automatically set the `noblur` property on glassed windows. Glass replaces Hyprland's blur; without `noblur`, Hyprland's cached-blur optimization (`blur:new_optimizations`) hides the glass on static windows. Set to `0` to manage `windowrule = noblur` yourself. |
+| `xray` | bool | `false` (`0` in .conf) | X-ray, as in Hyprland's `blur:xray`: the glass is sampled from a snapshot of the frame taken before any window is drawn (wallpaper and bottom layers only), so windows underneath never show through it, however light the blur. Per-window tags and per-layer `xray` override this either way. See [X-ray](#x-ray). |
 | `default_theme` | string | `dark` | Default theme: `dark` or `light` |
 | `default_preset` | string | `default` | Default preset name |
 
@@ -193,6 +194,7 @@ hg.layer("debug-panel", { exclude = true })
 | `live_resample` | bool | Per-layer override of `layers:live_resample` |
 | `mask_mode` | string | `"auto"`, `"region"` or `"alpha"`. See `layers:mask_mode` |
 | `exclude` | bool | Blacklist this namespace instead of whitelisting it |
+| `xray` | bool | X-ray for this layer, overriding the global `xray` either way (like Hyprland's `xray` layer rule). See [X-ray](#x-ray) |
 
 #### Legacy .conf config
 
@@ -211,6 +213,7 @@ hg.layer("debug-panel", { exclude = true })
 | `layers:mask_mode` | string | `auto` | Where the glass goes: `auto` = where the app requests blur, else where content is visible; `region` = only where the app requests blur; `alpha` = only where content is visible |
 | `layers:namespace_mask_modes` | string | `""` | Per-namespace `mask_mode` (`ns=mode` pairs, comma-separated) |
 | `layers:manage_blur` | bool | `true` (`1` in .conf) | Replace Hyprland's own blur with glass on glassed layers (`layerrule = ignorealpha` then has no effect, use `mask_threshold`). Set to `0` to keep Hyprland's blur |
+| `layers:namespace_xray` | string | `""` | Per-namespace x-ray (`ns=0` / `ns=1` pairs, comma-separated) |
 
 > Layer support hooks into Hyprland's internal render pipeline. This is version-sensitive and may break across Hyprland updates.
 
@@ -224,6 +227,28 @@ Override the global `enabled` setting per window via tags:
 
 - `hyprglass_disabled` — force the effect off on this window (wins over `hyprglass_enabled` if both present).
 - `hyprglass_enabled` — force the effect on this window. Useful with global `enabled = false` for a whitelist.
+- `hyprglass_xray` / `hyprglass_noxray` — x-ray on or off for this window, overriding the global `xray` (like Hyprland's `xray on` / `xray off` window rule; `noxray` wins if both are present).
+
+#### X-ray
+
+By default the glass is made from the live frame: the wallpaper plus whatever
+windows were already drawn beneath the glassed window, so with a weak blur
+those windows show through it. With x-ray the glass is sampled from a snapshot
+of the frame taken after the background and bottom layers and before any
+window — the wallpaper shows through, windows underneath never do, however
+light the blur. It is the same idea as Hyprland's `decoration:blur:xray`, and
+named the same way.
+
+```lua
+hg.config({ xray = true })                                              -- every glassed window and layer
+hl.window_rule({ match = { class = "foot" }, tag = "+hyprglass_xray" })   -- or per window
+hl.window_rule({ match = { class = "mpv" },  tag = "+hyprglass_noxray" }) -- opt a window out
+hg.layer("waybar", { xray = true })                                       -- or per layer
+```
+
+The snapshot is refreshed in the frame's damaged region for as long as any
+window or layer on that monitor has sampled it within the last ten seconds,
+and is dropped after that.
 
 #### Theme
 

--- a/src/GlassDecoration.cpp
+++ b/src/GlassDecoration.cpp
@@ -110,6 +110,23 @@ bool CGlassDecoration::resolveThemeIsDark() const {
     return true;
 }
 
+bool CGlassDecoration::resolveXray() const {
+    try {
+        const auto window = m_window.lock();
+        if (window && window->m_ruleApplicator) {
+            const auto& tags = window->m_ruleApplicator->m_tagKeeper;
+            // As with Hyprland's `xray off` window rule, off wins over the global.
+            if (tags.isTagged(std::string(TAG_NOXRAY)))
+                return false;
+            if (tags.isTagged(std::string(TAG_XRAY)))
+                return true;
+        }
+    } catch (...) {}
+
+    const auto& config = g_pGlobalState->config;
+    return config.xray && **config.xray;
+}
+
 std::string CGlassDecoration::resolvePresetName() const {
     try {
         const auto window = m_window.lock();
@@ -147,6 +164,12 @@ void CGlassDecoration::draw(PHLMONITOR monitor, float const& alpha) {
     updateNoBlurProp(enabled);
     if (!enabled)
         return;
+
+    // X-ray: ask for next frame's pre-window snapshot while we still sample it.
+    if (monitor && resolveXray()) {
+        auto& snapshot          = g_pGlobalState->backgroundSnapshots[monitor->m_id];
+        snapshot.requestedFrame = snapshot.frame;
+    }
 
     CGlassPassElement::SGlassPassData data{m_self, alpha};
     g_pHyprRenderer->m_renderPass.add(makeUnique<CGlassPassElement>(data));
@@ -196,6 +219,18 @@ void CGlassDecoration::renderPass(PHLMONITOR monitor, const float& alpha) {
     if (!source)
         return;
 
+    // What the glass is made from: the live frame (wallpaper plus whatever
+    // windows were already drawn beneath this one) or, with x-ray, the
+    // pre-window snapshot — wallpaper only. Until the snapshot is complete
+    // (the first frames after it was asked for, or after a mode change) fall
+    // back to the frame.
+    auto sampleSource = source;
+    if (monitor && resolveXray()) {
+        const auto it = g_pGlobalState->backgroundSnapshots.find(monitor->m_id);
+        if (it != g_pGlobalState->backgroundSnapshots.end() && it->second.complete && it->second.fb && it->second.fb->m_size == source->m_size)
+            sampleSource = it->second.fb;
+    }
+
     auto optBox = WindowGeometry::computeWindowBox(window, monitor);
     if (!optBox)
         return;
@@ -216,7 +251,7 @@ void CGlassDecoration::renderPass(PHLMONITOR monitor, const float& alpha) {
     float blurStrength   = resolvePresetFloat(ctx, &SPresetValues::blurStrength, &SOverridableConfig::blurStrength);
     int downscale        = blurStrength >= GlassRenderer::BLUR_DOWNSCALE_THRESHOLD ? GlassRenderer::BLUR_DOWNSCALE_MAX : 1;
 
-    GlassRenderer::sampleBackground(m_sampleFramebuffer, source, transformBox, m_samplePaddingRatio, downscale);
+    GlassRenderer::sampleBackground(m_sampleFramebuffer, sampleSource, transformBox, m_samplePaddingRatio, downscale);
 
     float blurRadius     = blurStrength * 12.0f / downscale;
     int blurIterations   = std::clamp(static_cast<int>(resolvePresetInt(ctx, &SPresetValues::blurIterations, &SOverridableConfig::blurIterations)), 1, 5);

--- a/src/GlassDecoration.hpp
+++ b/src/GlassDecoration.hpp
@@ -48,6 +48,7 @@ class CGlassDecoration : public IHyprWindowDecoration {
     void withdrawNoBlur();
 
     [[nodiscard]] bool        resolveEnabled() const;
+    [[nodiscard]] bool        resolveXray() const;
     [[nodiscard]] bool        resolveThemeIsDark() const;
     [[nodiscard]] std::string resolvePresetName() const;
 

--- a/src/GlassLayerSurface.cpp
+++ b/src/GlassLayerSurface.cpp
@@ -46,6 +46,22 @@ bool CGlassLayerSurface::resolveThemeIsDark() const {
     return true;
 }
 
+bool CGlassLayerSurface::resolveXray() const {
+    try {
+        // Per-namespace setting wins over the global, either way
+        const auto layerSurface = m_layerSurface.lock();
+        if (layerSurface) {
+            const auto& nsXray = g_pGlobalState->layerNamespaceXray;
+            const auto  it     = nsXray.find(layerSurface->m_namespace);
+            if (it != nsXray.end())
+                return it->second;
+        }
+    } catch (...) {}
+
+    const auto& config = g_pGlobalState->config;
+    return config.xray && **config.xray;
+}
+
 std::string CGlassLayerSurface::resolvePresetName() const {
     try {
         // Per-namespace preset override (highest priority)
@@ -200,6 +216,22 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     if (!source)
         return;
 
+    // X-ray: sample the pre-window snapshot (wallpaper only) once it is
+    // complete, and keep asking for it every frame so it stays fresh. A
+    // sample taken from the live frame while the snapshot is still filling
+    // in is cached like any other and replaced once, when the snapshot is
+    // there (or when x-ray is switched off again), so the cached-sample
+    // path costs the same as without x-ray.
+    auto       sampleSource = source;
+    const bool xray         = resolveXray();
+    if (xray && monitor) {
+        auto& snapshot          = g_pGlobalState->backgroundSnapshots[monitor->m_id];
+        snapshot.requestedFrame = snapshot.frame;
+        if (snapshot.complete && snapshot.fb && snapshot.fb->m_size == source->m_size)
+            sampleSource = snapshot.fb;
+    }
+    const bool fromSnapshot = sampleSource != source;
+
     auto layerBox = LayerGeometry::computeLayerBox(layerSurface, monitor);
     if (!layerBox)
         return;
@@ -220,7 +252,8 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
     const bool forceLive = config.layersForceLiveResample && **config.layersForceLiveResample;
     const bool backgroundChanged = !m_hasCachedSample ||
                                    currentGeneration != m_lastSceneGeneration ||
-                                   isAnimating || m_backgroundDirty || forceLive;
+                                   isAnimating || m_backgroundDirty || forceLive ||
+                                   fromSnapshot != m_cachedFromSnapshot;
 
     if (!layerSurface->m_mapped) {
         // During fade-out, re-sampling captures stale pixels. Reuse cached sample.
@@ -234,13 +267,14 @@ void CGlassLayerSurface::sampleAndRedirect(PHLMONITOR monitor, float alpha) {
         float blurStrength   = resolvePresetFloat(ctx, &SPresetValues::blurStrength, &SOverridableConfig::blurStrength);
         int downscale        = blurStrength >= GlassRenderer::BLUR_DOWNSCALE_THRESHOLD ? GlassRenderer::BLUR_DOWNSCALE_MAX : 1;
 
-        GlassRenderer::sampleBackground(m_sampleFramebuffer, source, transformBox, m_samplePaddingRatio, downscale);
+        GlassRenderer::sampleBackground(m_sampleFramebuffer, sampleSource, transformBox, m_samplePaddingRatio, downscale);
 
         float blurRadius     = blurStrength * 12.0f / downscale;
         int blurIterations   = std::clamp(static_cast<int>(resolvePresetInt(ctx, &SPresetValues::blurIterations, &SOverridableConfig::blurIterations)), 1, 5);
         GlassRenderer::blurBackground(m_sampleFramebuffer, blurRadius, blurIterations, source);
 
         m_hasCachedSample      = true;
+        m_cachedFromSnapshot   = fromSnapshot;
         m_lastSceneGeneration  = currentGeneration;
         m_backgroundDirty      = false;
     }

--- a/src/GlassLayerSurface.hpp
+++ b/src/GlassLayerSurface.hpp
@@ -44,6 +44,7 @@ class CGlassLayerSurface {
     std::chrono::steady_clock::time_point m_lastDirtyMark{};
 
     void damageSampleRegion();
+    bool         m_cachedFromSnapshot = false; // the cached sample came from the x-ray snapshot
 
     // Track last position/size to detect movement and expand damage
     Vector2D     m_lastPosition;
@@ -59,4 +60,5 @@ class CGlassLayerSurface {
     [[nodiscard]] bool           resolveThemeIsDark() const;
     [[nodiscard]] std::string    resolvePresetName() const;
     [[nodiscard]] ELayerMaskMode resolveMaskMode() const;
+    [[nodiscard]] bool           resolveXray() const;
 };

--- a/src/GlassSnapshotElement.cpp
+++ b/src/GlassSnapshotElement.cpp
@@ -1,0 +1,109 @@
+#include "GlassSnapshotElement.hpp"
+#include "Globals.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <GLES3/gl32.h>
+#include <hyprland/src/render/gl/GLFramebuffer.hpp>
+#include <hyprland/src/render/OpenGL.hpp>
+
+// The blit needs raw GL framebuffer ids. A framebuffer that is not GL-backed
+// (nothing else in the plugin renders to one either) just skips the snapshot.
+static std::optional<GLuint> fbId(const SP<Render::IFramebuffer>& framebuffer) {
+    auto* gl = dynamic_cast<Render::GL::CGLFramebuffer*>(framebuffer.get());
+    if (!gl)
+        return std::nullopt;
+    return gl->getFBID();
+}
+
+std::vector<UP<IPassElement>> CGlassSnapshotElement::draw() {
+    if (!g_pGlobalState)
+        return {};
+
+    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor.lock();
+    const auto source  = g_pHyprRenderer->m_renderData.currentFB;
+    if (!monitor || !source)
+        return {};
+
+    const auto it = g_pGlobalState->backgroundSnapshots.find(monitor->m_id);
+    if (it == g_pGlobalState->backgroundSnapshots.end())
+        return {};
+    auto& snapshot = it->second;
+
+    const int width  = static_cast<int>(source->m_size.x);
+    const int height = static_cast<int>(source->m_size.y);
+    if (width <= 0 || height <= 0)
+        return {};
+
+    const auto sourceId = fbId(source);
+    if (!sourceId)
+        return {};
+
+    if (!snapshot.fb)
+        snapshot.fb = g_pHyprRenderer->createFB("hyprglass-background");
+
+    if (static_cast<int>(snapshot.fb->m_size.x) != width || static_cast<int>(snapshot.fb->m_size.y) != height) {
+        if (!snapshot.fb->alloc(width, height, source->m_drmFormat))
+            return {};
+        const auto id = fbId(snapshot.fb);
+        if (!id)
+            return {};
+        // Fresh (or resized) snapshot: start from transparent black so the
+        // undamaged remainder never shows a stale frame, and have the whole
+        // monitor redrawn next frame so that remainder fills in at once.
+        glBindFramebuffer(GL_FRAMEBUFFER, *id);
+        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        snapshot.complete = false;
+        requestFullRedraw(monitor);
+    }
+
+    const auto snapshotId = fbId(snapshot.fb);
+    if (!snapshotId)
+        return {};
+
+    // Only the damaged region is guaranteed to hold freshly drawn background
+    // in the main framebuffer; outside it, the FB still carries the previous
+    // frame's final composite — windows included. Copy exactly the damage.
+    // The render pass scissors each element to its damage; that state would
+    // clip glBlitFramebuffer on the draw side, so switch it off for the copy
+    // and put it back the way it was.
+    //
+    // m_renderData.damage lives in the monitor's transformed (logical-pixel)
+    // space — the render pass clips it to m_transformedSize and scissor()
+    // rotates it into the framebuffer, whose orientation is the output's
+    // native one. Rotate it the same way here: on a 90°/270° monitor the raw
+    // rects address the wrong pixels and never cover the framebuffer, so the
+    // snapshot stayed transparent black where the copy missed and the glass
+    // rendered flat gray there.
+    CRegion damage = g_pHyprRenderer->m_renderData.damage.copy();
+    damage.intersect(CBox{{}, monitor->m_transformedSize});
+    damage.transform(Math::wlTransformToHyprutils(Math::invertTransform(monitor->m_transform)),
+                     monitor->m_transformedSize.x, monitor->m_transformedSize.y);
+    const bool  scissorWasOn = glIsEnabled(GL_SCISSOR_TEST) == GL_TRUE;
+    g_pHyprOpenGL->setCapStatus(GL_SCISSOR_TEST, false);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, *sourceId);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, *snapshotId);
+    for (const auto& rect : damage.getRects()) {
+        const int x1 = std::max(0, static_cast<int>(rect.x1));
+        const int y1 = std::max(0, static_cast<int>(rect.y1));
+        const int x2 = std::min(width, static_cast<int>(rect.x2));
+        const int y2 = std::min(height, static_cast<int>(rect.y2));
+        if (x2 <= x1 || y2 <= y1)
+            continue;
+        glBlitFramebuffer(x1, y1, x2, y2, x1, y1, x2, y2, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    }
+    g_pHyprOpenGL->setCapStatus(GL_SCISSOR_TEST, scissorWasOn);
+
+    // Complete once a frame's damage has covered the whole monitor: from then
+    // on, whatever the damage leaves untouched is background copied earlier.
+    if (!snapshot.complete) {
+        CRegion missing{0, 0, static_cast<double>(width), static_cast<double>(height)};
+        missing.subtract(damage);
+        snapshot.complete = missing.empty();
+    }
+
+    // Leave the renderer's target bound the way it expects it.
+    source->bind();
+    return {};
+}

--- a/src/GlassSnapshotElement.hpp
+++ b/src/GlassSnapshotElement.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <hyprland/src/render/pass/PassElement.hpp>
+#include <hyprland/src/helpers/memory/Memory.hpp>
+#include <hyprland/src/managers/eventLoop/EventLoopManager.hpp>
+#include <hyprland/src/render/Renderer.hpp>
+
+// X-ray support. Copies the frame's damaged region into a per-monitor
+// snapshot framebuffer. Added to the render pass at RENDER_PRE_WINDOWS, i.e.
+// after the background and bottom layers (the wallpaper) and before any
+// window, so the snapshot holds the desktop with no windows in it. Windows and
+// layers with x-ray sample their glass from this snapshot instead of the live
+// frame: the wallpaper shows through them, windows underneath never do.
+class CGlassSnapshotElement : public IPassElement {
+  public:
+    CGlassSnapshotElement()           = default;
+    ~CGlassSnapshotElement() override = default;
+
+    std::vector<UP<IPassElement>> draw() override;
+    [[nodiscard]] bool            needsLiveBlur() override { return false; }
+    [[nodiscard]] bool            needsPrecomputeBlur() override { return false; }
+    [[nodiscard]] bool            disableSimplification() override { return true; }
+    [[nodiscard]] bool            undiscardable() override { return true; }
+
+    [[nodiscard]] const char*      passName() override { return "CGlassSnapshotElement"; }
+    [[nodiscard]] ePassElementType type() override { return EK_CUSTOM; }
+};
+
+// Have the monitor redrawn in full on the next frame, so a fresh snapshot is
+// populated at once. Deferred to the event loop: this is called from inside
+// the render pass, where the current frame's damage is already fixed.
+inline void requestFullRedraw(PHLMONITOR monitor) {
+    g_pEventLoopManager->doLater([weak = PHLMONITORREF{monitor}] {
+        if (const auto m = weak.lock())
+            g_pHyprRenderer->damageMonitor(m);
+    });
+}

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -70,6 +70,31 @@ struct SGlobalState {
             sceneGeneration[mon->m_id]++;
     }
 
+    // X-ray: pre-window snapshot of each monitor's frame (wallpaper + bottom
+    // layers, no windows), refreshed by CGlassSnapshotElement in the damaged
+    // region. Keyed by MONITORID; entries go with the monitor.
+    struct SBackgroundSnapshot {
+        SP<Render::IFramebuffer> fb;
+        // Monitor frames, counted at RENDER_BEGIN of a monitor render, and
+        // the frame in which something last sampled the snapshot (a sampler's
+        // draw() runs while that frame's pass is built). The snapshot is kept
+        // fresh — every frame's damage copied — while anything has sampled it
+        // within the last IDLE_FRAMES, whether or not a sampler is drawn in a
+        // given frame: solitary fullscreen clients, exports and mirrors skip
+        // the decorations, and treating such a frame as a lapse meant a
+        // stale snapshot and a full redraw every time one went by.
+        uint64_t frame          = 0;
+        uint64_t requestedFrame = 0;
+        uint64_t addedFrame     = 0; // the element is added once per frame
+        // A whole-monitor damage frame has been copied since the snapshot was
+        // (re)allocated; until then samplers use the live frame.
+        bool complete = false;
+    };
+    std::unordered_map<MONITORID, SBackgroundSnapshot> backgroundSnapshots;
+
+    // Per-namespace x-ray for layer surfaces (hg.layer xray / layers:namespace_xray)
+    std::unordered_map<std::string, bool> layerNamespaceXray;
+
     // renderLayer hook
     CFunctionHook* renderLayerHook = nullptr;
     // damageSurface hook (live layer re-render)

--- a/src/PluginConfig.cpp
+++ b/src/PluginConfig.cpp
@@ -43,6 +43,7 @@ std::optional<ELayerMaskMode> parseLayerMaskMode(std::string_view value) {
 void registerConfig(HANDLE handle) {
     addConfigValue<Config::Values::Int>(handle, ConfigKeys::ENABLED, Config::INTEGER{1});
     addConfigValue<Config::Values::Int>(handle, ConfigKeys::MANAGE_WINDOW_BLUR, Config::INTEGER{1});
+    addConfigValue<Config::Values::Int>(handle, ConfigKeys::XRAY, Config::INTEGER{0});
     addConfigValue<Config::Values::String>(handle, ConfigKeys::DEFAULT_THEME, Config::STRING{"dark"});
     addConfigValue<Config::Values::String>(handle, ConfigKeys::DEFAULT_PRESET, Config::STRING{"default"});
 
@@ -60,6 +61,7 @@ void registerConfig(HANDLE handle) {
     addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_MASK_MODE, Config::STRING{"auto"});
     addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_MODES, Config::STRING{});
     addConfigValue<Config::Values::Int>(handle, ConfigKeys::LAYERS_MANAGE_BLUR, Config::INTEGER{1});
+    addConfigValue<Config::Values::String>(handle, ConfigKeys::LAYERS_NAMESPACE_XRAY, Config::STRING{});
 
     // Global level — real defaults for effect settings,
     // sentinel for theme-sensitive settings (fallback to hardcoded theme defaults)
@@ -170,6 +172,7 @@ static void initOverridablePointers(HANDLE handle, SOverridableConfig& layer,
 void initConfigPointers(HANDLE handle, SPluginConfig& config) {
     config.enabled          = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::ENABLED);
     config.manageWindowBlur = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::MANAGE_WINDOW_BLUR);
+    config.xray             = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::XRAY);
     config.defaultTheme  = getStringPtr(handle, ConfigKeys::DEFAULT_THEME);
     config.defaultPreset = getStringPtr(handle, ConfigKeys::DEFAULT_PRESET);
 
@@ -186,6 +189,7 @@ void initConfigPointers(HANDLE handle, SPluginConfig& config) {
     config.layersMaskMode           = getStringPtr(handle, ConfigKeys::LAYERS_MASK_MODE);
     config.layersNamespaceMaskModes = getStringPtr(handle, ConfigKeys::LAYERS_NAMESPACE_MASK_MODES);
     config.layersManageBlur         = getStaticPtr<Hyprlang::INT>(handle, ConfigKeys::LAYERS_MANAGE_BLUR);
+    config.layersNamespaceXray           = getStringPtr(handle, ConfigKeys::LAYERS_NAMESPACE_XRAY);
 
     initOverridablePointers(handle, config.global,
         ConfigKeys::BLUR_STRENGTH, ConfigKeys::BLUR_ITERATIONS,
@@ -585,6 +589,7 @@ struct SPendingLayer {
     bool                          exclude       = false;
     int                           liveResample  = -1; // -1 = not set
     std::optional<ELayerMaskMode> maskMode;
+    int                           xray          = -1; // -1 = not set, 0 = off, 1 = on
 };
 
 static std::vector<SPendingLayer> s_pendingLayers;
@@ -621,6 +626,11 @@ static int handleLuaLayer(lua_State* L) {
         if (lua_isstring(L, -1))
             entry.maskMode = parseLayerMaskMode(lua_tostring(L, -1));
         lua_pop(L, 1);
+
+        lua_getfield(L, 2, "xray");
+        if (lua_isboolean(L, -1))
+            entry.xray = lua_toboolean(L, -1) ? 1 : 0;
+        lua_pop(L, 1);
     }
 
     s_pendingLayers.push_back(std::move(entry));
@@ -646,6 +656,8 @@ void commitPendingLayers() {
                 g_pGlobalState->layerNamespaceLiveResample[entry.ns] = entry.liveResample != 0;
             if (entry.maskMode)
                 g_pGlobalState->layerNamespaceMaskModes[entry.ns] = *entry.maskMode;
+            if (entry.xray != -1)
+                g_pGlobalState->layerNamespaceXray[entry.ns] = entry.xray == 1;
         }
     }
     s_pendingLayers.clear();

--- a/src/PluginConfig.hpp
+++ b/src/PluginConfig.hpp
@@ -19,6 +19,13 @@ inline constexpr std::string_view TAG_PRESET_PREFIX = "hyprglass_preset_";
 inline constexpr std::string_view TAG_ENABLED  = "hyprglass_enabled";
 inline constexpr std::string_view TAG_DISABLED = "hyprglass_disabled";
 
+// Window tags for per-window x-ray (see `xray`): sample the glass from the
+// pre-window snapshot of the frame (wallpaper and bottom layers only) instead
+// of the live frame, so windows underneath never show through the glass. Both
+// override the global setting; like Hyprland's `xray off` rule, `noxray` wins.
+inline constexpr std::string_view TAG_XRAY   = "hyprglass_xray";
+inline constexpr std::string_view TAG_NOXRAY = "hyprglass_noxray";
+
 // Hyprland stores dynamic tags (`tagwindow` dispatcher, dynamic window rules)
 // with a trailing '*'. CTagKeeper::isTagged() normalizes this for exact lookups,
 // but code iterating getTags() or registering preset names must strip it itself
@@ -49,6 +56,7 @@ inline constexpr auto ENABLED            = "plugin:hyprglass:enabled";
 inline constexpr auto DEFAULT_THEME      = "plugin:hyprglass:default_theme";
 inline constexpr auto DEFAULT_PRESET     = "plugin:hyprglass:default_preset";
 inline constexpr auto MANAGE_WINDOW_BLUR = "plugin:hyprglass:manage_window_blur";
+inline constexpr auto XRAY               = "plugin:hyprglass:xray";
 
 // Preset keyword, registered as unscoped because Hyprlang does not dispatch
 // scoped keyword handlers inside the plugin special category.
@@ -87,6 +95,7 @@ inline constexpr auto LAYERS_FORCE_LIVE_RESAMPLE        = "plugin:hyprglass:laye
 inline constexpr auto LAYERS_MASK_MODE                  = "plugin:hyprglass:layers:mask_mode";
 inline constexpr auto LAYERS_NAMESPACE_MASK_MODES       = "plugin:hyprglass:layers:namespace_mask_modes";
 inline constexpr auto LAYERS_MANAGE_BLUR                = "plugin:hyprglass:layers:manage_blur";
+inline constexpr auto LAYERS_NAMESPACE_XRAY             = "plugin:hyprglass:layers:namespace_xray";
 
 // Overridable — dark theme overrides
 inline constexpr auto DARK_BLUR_STRENGTH        = "plugin:hyprglass:dark:blur_strength";
@@ -207,6 +216,10 @@ struct SPluginConfig {
     // against the live framebuffer (which contains the glass) instead of its
     // pre-frame cached blur.
     Hyprlang::INT* const* manageWindowBlur = nullptr;
+    // X-ray, as in Hyprland's blur:xray: glass samples the pre-window snapshot
+    // of the frame (wallpaper and bottom layers only), so windows underneath
+    // never show through it. Per-window tags and per-layer settings override.
+    Hyprlang::INT* const* xray             = nullptr;
     StringConfigPtr      defaultTheme;
     StringConfigPtr      defaultPreset;
 
@@ -223,6 +236,7 @@ struct SPluginConfig {
     StringConfigPtr       layersMaskMode;
     StringConfigPtr       layersNamespaceMaskModes;
     Hyprlang::INT* const* layersManageBlur               = nullptr;
+    StringConfigPtr       layersNamespaceXray;
 
     SOverridableConfig global;
     SOverridableConfig dark;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "GlassLayerPassElement.hpp"
 #include "GlassLayerSurface.hpp"
 #include "GlassRenderer.hpp"
+#include "GlassSnapshotElement.hpp"
 #include "Globals.hpp"
 #include "PluginConfig.hpp"
 
@@ -232,6 +233,14 @@ static void parseLayerNamespaceFilters() {
         if (auto mode = parseLayerMaskMode(val))
             g_pGlobalState->layerNamespaceMaskModes[ns] = *mode;
     });
+
+    g_pGlobalState->layerNamespaceXray.clear();
+    parseKeyValuePairs(config.layersNamespaceXray, '=', [&](const std::string& ns, const std::string& val) {
+        if (val == "1" || val == "true" || val == "on" || val == "yes")
+            g_pGlobalState->layerNamespaceXray.emplace(ns, true);
+        else if (val == "0" || val == "false" || val == "off" || val == "no")
+            g_pGlobalState->layerNamespaceXray.emplace(ns, false);
+    });
 }
 
 static bool shouldGlassLayer(PHLLS layerSurface) {
@@ -436,6 +445,47 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
             if (ws) if (auto mon = ws->m_monitor.lock()) g_pGlobalState->bumpSceneGeneration(mon);
         }));
 
+    // X-ray: right after the background and bottom layers and before any
+    // window, copy the frame's damaged region into the monitor's snapshot.
+    // Nothing is allocated until a window or layer asks; the copy then runs
+    // every monitor frame for as long as something has asked within the last
+    // IDLE_FRAMES, and the snapshot is dropped after that. Only real monitor
+    // renders count: exports, mirrors and closing-window snapshots have their
+    // own passes with their own pre-window stage.
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.render.stage.listen([&](eRenderStage stage) {
+        if ((stage != RENDER_BEGIN && stage != RENDER_PRE_WINDOWS) || !g_pGlobalState || g_pHyprRenderer->m_bRenderingSnapshot ||
+            g_pHyprRenderer->m_renderData.projectionType != Render::RPT_MONITOR)
+            return;
+        const auto monitor = g_pHyprRenderer->m_renderData.pMonitor.lock();
+        if (!monitor)
+            return;
+        const auto it = g_pGlobalState->backgroundSnapshots.find(monitor->m_id);
+        if (it == g_pGlobalState->backgroundSnapshots.end())
+            return;
+        auto& snapshot = it->second;
+        if (stage == RENDER_BEGIN) {
+            snapshot.frame++;
+            return;
+        }
+        if (snapshot.addedFrame == snapshot.frame) // this frame's pass already has the element
+            return;
+        constexpr uint64_t IDLE_FRAMES = 600; // ~10 s at 60 Hz without a sampler: let it go
+        if (snapshot.frame > snapshot.requestedFrame + IDLE_FRAMES) {
+            g_pGlobalState->backgroundSnapshots.erase(it);
+            return;
+        }
+        snapshot.addedFrame = snapshot.frame;
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CGlassSnapshotElement>());
+    }));
+
+    auto dropMonitorSnapshot = [](PHLMONITOR m) {
+        if (!g_pGlobalState || !m)
+            return;
+        g_pGlobalState->backgroundSnapshots.erase(m->m_id);
+    };
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.monitor.removed.listen([=](PHLMONITOR m) { dropMonitorSnapshot(m); }));
+    g_pGlobalState->listeners.push_back(Event::bus()->m_events.monitor.destroyMon.listen([=](PHLMONITOR m) { dropMonitorSnapshot(m); }));
+
     // Clear pending presets/layers before config re-parse, commit after
     g_pGlobalState->listeners.push_back(Event::bus()->m_events.config.preReload.listen([&]() {
         clearPendingPresets();
@@ -528,6 +578,8 @@ APICALL EXPORT void PLUGIN_EXIT() {
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassPassElement");
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassLayerPassElement");
     g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassLayerCompositeElement");
+    g_pHyprRenderer->m_renderPass.removeAllOfType("CGlassSnapshotElement");
+    g_pGlobalState->backgroundSnapshots.clear();
 
     for (auto& decoration : g_pGlobalState->decorations) {
         if (auto* deco = decoration.get())


### PR DESCRIPTION
## What

X-ray for hyprglass, named and shaped after Hyprland's `decoration:blur:xray` (closes #68): the glass is sampled from a snapshot of the frame taken **after the background and bottom layers and before any window** — the wallpaper only — instead of the live frame. Windows underneath a glassed window then never show through it, however light the blur. Off by default; nothing changes for anyone who does not turn it on.

| Where | How |
|---|---|
| Global | `plugin:hyprglass:xray = true` (`hg.config({ xray = true })`) — every glassed window and layer |
| Per window | tags `hyprglass_xray` / `hyprglass_noxray`, overriding the global either way; `noxray` wins if both are present, like Hyprland's `xray off` rule |
| Per layer | `hg.layer("waybar", { xray = true })`, or `layers:namespace_xray = waybar=1` in .conf |

## Why

With a light preset (a `blur_strength` of 0.5–2) the text of a window beneath a glassed window is readable through it, and even the 30×5 frost shows colour smudges of what is underneath. For a "pane lying on the desktop" look you want the wallpaper through the pane and nothing else, and today the only way to hide the windows beneath is to blur hard enough to destroy them. Same motivation as Hyprland's own xray, hence the same name.

## How

- `CGlassSnapshotElement`, a pass element added at `RENDER_PRE_WINDOWS` (Event bus `render.stage`), copies the frame's **damaged region** from the current framebuffer into a per-monitor snapshot FB. Only the damaged region is guaranteed to hold freshly drawn background; outside it the main FB still carries the previous frame's composite, windows included, so nothing else is copied.
- Windows and layers with x-ray stamp the monitor's snapshot with the frame they were drawn in (frames are counted at `RENDER_BEGIN` of monitor renders; exports, mirrors and closing-window snapshots have their own passes and are ignored). The element is added once per frame for as long as something has asked within the last 600 frames, and the snapshot is dropped after that. Copying every frame's damage regardless of whether a sampler is drawn in that particular frame matters: solitary fullscreen clients, exports and mirrors skip the decorations, and an earlier version that treated such a frame as a lapse re-activated the snapshot and asked for a full redraw on every one of them.
- A fresh or resized snapshot has the monitor redrawn in full once (deferred to the event loop, since the current frame's damage is already fixed) and is used only after that full copy has landed. Until then samplers fall back to the live frame, so nobody ever samples a half-filled snapshot — the padding ring around a window is not part of its own damage, so without this the first frames showed a dark fringe.
- Listeners are owned by the plugin state, as in v0.8.
- Layers keep their cached-sample optimisation. A sample taken from the live frame while the snapshot is still filling in is cached like any other and replaced once, when the snapshot is there (or when x-ray is switched off), so the cached path costs the same as without x-ray.
- Snapshot framebuffers are dropped with their monitor (`monitor.removed` / `destroyMon`) and on plugin exit. Not added while Hyprland renders a closing-window snapshot. The blit restores the scissor state it found, and skips a framebuffer that is not GL-backed rather than dereferencing a failed cast.

## Testing

Hyprland 0.56.2, three monitors (scales 2 / 1.5 / 1.5). Floated a glassed terminal over a terminal full of text and compared with and without x-ray: with the 30×5 frost and with a 0.5×1 preset the text beneath is readable without it and gone with it, while the wallpaper shows through; pixel-compared a full cycle of on and off back to an identical frame. Running for a day across theme switches, monitor DPMS cycles and plugin reloads. Before/after captures are in the comments.

## Cost

Per rendered frame, on a monitor where at least one window or layer samples the snapshot: one `glBlitFramebuffer` of the frame's damaged region into the snapshot FB. A hyprglass window already damages its box every frame for the live blur, so that copy is about the size of the glassed windows; only a full-damage frame (animation, wallpaper change) copies the whole frame. No extra sample or blur passes: windows re-sample every frame as before, layers keep their cache. Nothing at all runs when no window or layer has sampled for ten seconds. One full redraw of the monitor when x-ray starts on it, or after the snapshot was resized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFJySqdVsqmGBeYk2h44hj
